### PR TITLE
Increase version data type to accomodate large timestamps

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -108,7 +108,7 @@ module.exports = function (config) {
 
         commonClient.queries.getCurrentVersion = 'SELECT TOP 1 version FROM schemaversion ORDER BY version DESC';
         commonClient.queries.checkTable = "SELECT * FROM information_schema.tables WHERE table_schema = 'dbo' AND table_name = 'schemaversion'";
-        commonClient.queries.makeTable = "CREATE TABLE schemaversion (version INT PRIMARY KEY); INSERT INTO schemaversion (version) VALUES (0);";
+        commonClient.queries.makeTable = "CREATE TABLE schemaversion (version BIGINT PRIMARY KEY); INSERT INTO schemaversion (version) VALUES (0);";
 
         commonClient.createConnection = function (cb) {
             commonClient.dbConnection = commonClient.dbDriver.connect(sqlconfig, function (err) {


### PR DESCRIPTION
We are using timestamps generated by [moment](https://github.com/moment/moment/) and ran into an arithmetic overflow trying to store a typical timestamp. For example, this:
```js
var timestamp = moment.utc().valueOf();
console.log(timestamp);
-- 1434398370040
```
This value cannot be stored as INT.  This PR changes the data type of the column to BIGINT, which works fine.

I looked through the tests, and wasn't sure how you wanted this tested.  Let me know if I need to do anything further to help with this.