### PR TITLE
Cross platform consistent md5 checksum support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "async": "0.2.x",
     "mssql": "2.x.x",
     "mysql": "2.x.x",
+    "newline": "0.0.3",
     "pg.js": "4.x.x"
   },
   "repository": {

--- a/postgrator.js
+++ b/postgrator.js
@@ -97,7 +97,7 @@ var getMigrations = function () {
 				action: m[1],
 				filename: file,
 				name: name,
-				md5: fileChecksum(config.migrationDirectory + "/" + file)
+				md5: fileChecksum(config.migrationDirectory + "/" + file, config.newline)
 			});
 		}
 	});
@@ -395,10 +395,15 @@ function prep (callback) {
 
  ================================================================= */
 
-function fileChecksum (filename) {
-	return checksum(fs.readFileSync(filename, 'utf8'));
+function fileChecksum (filename, newline) {
+	return checksum(fs.readFileSync(filename, 'utf8'), newline);
 }
 
-function checksum (str) {
+function checksum (str, nl) {
+  if (nl) {
+    var newline = require('newline');
+    console.log('Converting newline from: ', newline.detect(str), 'to:', nl);
+    str = newline.set(str, nl);
+  }
 	return crypto.createHash('md5').update(str, 'utf8').digest('hex');
 }

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,23 @@ Postgrator automatically determines whether it needs to go "up" or "down", and w
 
 If a migration fails, Postgrator will stop running any further migrations. It is up to you to migrate back down to the version you started at if you are running several migration scripts. Because of this, keep in mind how you write your SQL - You may (or may not) want to write your SQL defensively (ie, check for pre-existing objects before you create new ones).
 
+## Cross platform line feeds
+
+Line feeds: Unix/Mac uses LF, Windows uses 'CRLF', this causes problems for postgrator when calculating the md5 checksum of the migration files - particularly if some developers are on windows, some are on mac, etc. To negate this, you can use the `newline` config flag to tell postgrator to always use a particular line feed, e.g.
+
+```
+postgrator.setConfig({
+    migrationDirectory: __dirname + '/migrations', 
+    driver: 'pg', // or pg.js, mysql, mssql, tedious
+    host: '127.0.0.1',
+    database: 'databasename',
+    username: 'username',
+    password: 'password',
+    newline: 'CRLF'
+});
+```
+
+Under the hood this uses the [newline](www.npmjs.com/package/newline) module for detecting and setting line feeds.
 
 
 ## Installation


### PR DESCRIPTION
Line feeds: Unix/Mac uses LF, Windows uses 'CRLF', this causes problems for postgrator when calculating the md5 checksum of the migration files - particularly if some developers are on windows, some are on mac, etc. To negate this, you can use the `newline` config flag to tell postgrator to always use a particular line feed, e.g.

```
postgrator.setConfig({
    migrationDirectory: __dirname + '/migrations', 
    driver: 'pg', // or pg.js, mysql, mssql, tedious
    host: '127.0.0.1',
    database: 'databasename',
    username: 'username',
    password: 'password',
    newline: 'CRLF'
});
```