### PR TITLE
Configure schema table

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -13,6 +13,7 @@ module.exports = function (config) {
         connected: false,
         dbDriver: null,
         dbConnection: null,
+        schemaTable: config.schemaTable,
         createConnection: function () {},
         runQuery: function (query, cb) {
             cb();
@@ -21,7 +22,7 @@ module.exports = function (config) {
             cb();
         },
         queries: {
-            getCurrentVersion: 'SELECT version FROM schemaversion ORDER BY version DESC LIMIT 1',
+            getCurrentVersion: 'SELECT version FROM ' + config.schemaTable + ' ORDER BY version DESC LIMIT 1',
             checkTable: "",
             makeTable: ""
         }
@@ -31,8 +32,8 @@ module.exports = function (config) {
 
         commonClient.dbDriver = require('mysql');
 
-        commonClient.queries.checkTable = "SELECT * FROM information_schema.tables WHERE table_schema = '" + config.database + "' AND table_name = 'schemaversion';";
-        commonClient.queries.makeTable = "CREATE TABLE schemaversion (version INT, PRIMARY KEY (version)); INSERT INTO schemaversion (version) VALUES (0);";
+        commonClient.queries.checkTable = "SELECT * FROM information_schema.tables WHERE table_schema = '" + config.database + "' AND table_name = '" + config.schemaTable + "';";
+        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version INT, PRIMARY KEY (version)); INSERT INTO " + config.schemaTable + " (version) VALUES (0);";
 
         commonClient.createConnection = function (cb) {
             var connection = commonClient.dbDriver.createConnection({
@@ -70,10 +71,11 @@ module.exports = function (config) {
 
         var connectionString = config.connectionString || "tcp://" + config.username + ":" + config.password + "@" + config.host + "/" + config.database;
 
-        commonClient.queries.checkTable = "SELECT * FROM pg_catalog.pg_tables WHERE schemaname = CURRENT_SCHEMA AND tablename = 'schemaversion';";
-        commonClient.queries.makeTable = "CREATE TABLE schemaversion (version INT PRIMARY KEY, name TEXT DEFAULT '', md5 TEXT DEFAULT ''); INSERT INTO schemaversion (version, name, md5) VALUES (0, '', '');";
+        commonClient.queries.checkTable = "SELECT * FROM pg_catalog.pg_tables WHERE schemaname = CURRENT_SCHEMA AND tablename = '" + config.schemaTable + "';";
+        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version INT PRIMARY KEY, name TEXT DEFAULT '', md5 TEXT DEFAULT ''); INSERT INTO " + config.schemaTable + " (version, name, md5) VALUES (0, '', '');";
 
         commonClient.createConnection = function (cb) {
+          console.log(connectionString); process.exit();
             commonClient.dbConnection = new commonClient.dbDriver.Client(connectionString);
             commonClient.dbConnection.connect(function (err) {
                 cb(err);
@@ -106,9 +108,9 @@ module.exports = function (config) {
             requestTimeout: oneHour
         };
 
-        commonClient.queries.getCurrentVersion = 'SELECT TOP 1 version FROM schemaversion ORDER BY version DESC';
-        commonClient.queries.checkTable = "SELECT * FROM information_schema.tables WHERE table_schema = 'dbo' AND table_name = 'schemaversion'";
-        commonClient.queries.makeTable = "CREATE TABLE schemaversion (version BIGINT PRIMARY KEY); INSERT INTO schemaversion (version) VALUES (0);";
+        commonClient.queries.getCurrentVersion = 'SELECT TOP 1 version FROM ' + config.schemaTable + ' ORDER BY version DESC';
+        commonClient.queries.checkTable = "SELECT * FROM information_schema.tables WHERE table_schema = 'dbo' AND table_name = '" + config.schemaTable + "'";
+        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version BIGINT PRIMARY KEY); INSERT INTO " + config.schemaTable + " (version) VALUES (0);";
 
         commonClient.createConnection = function (cb) {
             commonClient.dbConnection = commonClient.dbDriver.connect(sqlconfig, function (err) {

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ var postgrator = require('postgrator');
 
 postgrator.setConfig({
     migrationDirectory: __dirname + '/migrations', 
+    schemaTable: 'schemaversion', // optional. default is 'schemaversion'
     driver: 'pg', // or pg.js, mysql, mssql, tedious
     host: '127.0.0.1',
     database: 'databasename',
@@ -78,6 +79,7 @@ For SQL Server, you may optionally provide an additional options configuration. 
 ```js  
 postgrator.setConfig({
     migrationDirectory: __dirname + '/migrations', 
+    schemaTable: 'schemaversion', // optional. default is 'schemaversion'
     driver: 'pg', // or pg.js, mysql, mssql, tedious
     host: '127.0.0.1',
     database: 'databasename',
@@ -121,9 +123,9 @@ Despite the major version bump, postgrator's API has not changed. Some of its be
 
 ## What Postgrator is doing
 
-When first run against your database, *Postgrator will create a table called schemaversion.* Postgrator relies on this table to track what version the database is at. 
+When first run against your database, *Postgrator will create the table specified by config.schemaTable.* Postgrator relies on this table to track what version the database is at. 
 
-Postgrator automatically determines whether it needs to go "up" or "down", and will update the schemaversion table accordingly. If the database is already at the version specified to migrate to, Postgrator does nothing.
+Postgrator automatically determines whether it needs to go "up" or "down", and will update the schemaTable accordingly. If the database is already at the version specified to migrate to, Postgrator does nothing.
 
 If a migration fails, Postgrator will stop running any further migrations. It is up to you to migrate back down to the version you started at if you are running several migration scripts. Because of this, keep in mind how you write your SQL - You may (or may not) want to write your SQL defensively (ie, check for pre-existing objects before you create new ones).
 


### PR DESCRIPTION
I need to manage multiple components in the same application that have their own migration paths, but the limitation of a single schemaversion table gets in the way.

The simplest way to implement this would be to make it configurable so I could use different tables for this, which is what I ended up doing.

One note though: I wanted to write some tests for this, but the default test connection is using an amazon aws instance of postgres, which I seem to have left in a broken state by stopping a test half-way.

Is there a reason for the aws instance being used? Otherwise, I think we should move to travis-ci and localhost for testing instead.

