### PR TITLE
Makes the request timeout option configurable

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -104,7 +104,7 @@ module.exports = function (config) {
             server: config.host,
             database: config.database,
             options: config.options,
-            requestTimeout: oneHour
+            requestTimeout: config.requestTimeout || oneHour
         };
 
         commonClient.queries.getCurrentVersion = 'SELECT TOP 1 version FROM ' + config.schemaTable + ' ORDER BY version DESC';

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@ postgrator.setConfig({
     database: 'databasename',
     username: 'username',
     password: 'password',
+    requestTimeout: 1000 * 60 * 60, //optional. default is one hour
     options: {
         encrypt: true
     }


### PR DESCRIPTION
The request timeout was hardcoded as one hour for mssql connections.
This change makes this option configurable if the user wishes to
perform larger scale data migrations in mssql. The default value
remains as one hour.