### PR TITLE
Added support for mssql batches delimited by GO.

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -119,9 +119,19 @@ module.exports = function (config) {
 
         commonClient.runQuery = function (query, cb) {
             var request = new commonClient.dbDriver.Request();
-            request.batch(query, function (err, result) {
-                cb(err, {rows: result});
-            });
+            var batches = query.split(/^\s*GO\s*$/im);
+
+            var runBatch = function(batchIndex) {
+                request.batch(batches[batchIndex], function (err, result) {
+                    if (err || batchIndex === batches.length - 1) {
+                        cb(err, {rows: result});
+                    } else {
+                        runBatch(batchIndex + 1);
+                    }
+                });
+            };
+
+            runBatch(0);
         };
 
         commonClient.endConnection = function (cb) {


### PR DESCRIPTION
Several types of DDL statements in MSSQL insist on being the only thing in a batch. The MSSQL tooling uses `GO` to delimit batches in a single script so developers don't have to create multiple files for what is logically a single task or migration.

https://msdn.microsoft.com/en-us/library/ms188037.aspx

I added support for the same convention in the mssql implementation of commonClient.runQuery. I did not add support for the optional `count` parameter, as I have never seen it used anywhere, but I could add that if you think it is important.