### PR TITLE
Fix for pg authentication issue in node 6+

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -68,7 +68,7 @@ module.exports = function (config) {
 
     } else if (config.driver === 'pg' || config.driver === 'pg.js') {
 
-        commonClient.dbDriver = require('pg.js');
+        commonClient.dbDriver = require('pg');
 
         // for backward compatibility, allows to specify port within host
         if (config.port) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mssql": "2.x.x",
     "mysql": "2.x.x",
     "newline": "0.0.3",
-    "pg.js": "4.x.x"
+    "pg": "^4.5.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- There is a change in `Buffer` in node 6+ that causes an issue with
  authentication in the `pg`/`pg.js` modules.
- See https://github.com/brianc/node-postgres/issues/1018
- Which references: https://github.com/brianc/node-postgres/issues/1000
- This commit changes the pg library dependency in postgrator to the version that
  contains the fix for this issue.

Basically, in node 6+, `postgrator` is intermittently failing when trying to run the migrations.  I don't know why it's intermittent, and not just an error everytime, but that seems to be what others are seeing.  `pg.js` 4.1.1 (the latest `pg.js` version) appears to still have the issue, but using `pg` 4.5.5 or later appears to fix the issue.