### PR TITLE
MySQL and PostgreSQL now use BIGINT for version

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -33,7 +33,7 @@ module.exports = function (config) {
         commonClient.dbDriver = require('mysql');
 
         commonClient.queries.checkTable = "SELECT * FROM information_schema.tables WHERE table_schema = '" + config.database + "' AND table_name = '" + config.schemaTable + "';";
-        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version INT, PRIMARY KEY (version)); INSERT INTO " + config.schemaTable + " (version) VALUES (0);";
+        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version BIGINT, PRIMARY KEY (version)); INSERT INTO " + config.schemaTable + " (version) VALUES (0);";
 
         commonClient.createConnection = function (cb) {
             var connection = commonClient.dbDriver.createConnection({
@@ -80,7 +80,7 @@ module.exports = function (config) {
         var connectionString = config.connectionString || "tcp://" + config.username + ":" + config.password + "@" + config.host + "/" + config.database;
 
         commonClient.queries.checkTable = "SELECT * FROM pg_catalog.pg_tables WHERE schemaname = CURRENT_SCHEMA AND tablename = '" + config.schemaTable + "';";
-        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version INT PRIMARY KEY, name TEXT DEFAULT '', md5 TEXT DEFAULT ''); INSERT INTO " + config.schemaTable + " (version, name, md5) VALUES (0, '', '');";
+        commonClient.queries.makeTable = "CREATE TABLE " + config.schemaTable + " (version BIGINT PRIMARY KEY, name TEXT DEFAULT '', md5 TEXT DEFAULT ''); INSERT INTO " + config.schemaTable + " (version, name, md5) VALUES (0, '', '');";
 
         commonClient.createConnection = function (cb) {
             commonClient.dbConnection = new commonClient.dbDriver.Client(connectionString);


### PR DESCRIPTION
This aligns MySQL and PostgreSQL with MSSQL, and lets those databases have timestamps (eg `201606091245`) as version numbers.