### PR TITLE
Add ssl support to the pg driver

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -69,7 +69,9 @@ module.exports = function (config) {
     } else if (config.driver === 'pg' || config.driver === 'pg.js') {
 
         commonClient.dbDriver = require('pg');
-
+        if (config.ssl){
+            commonClient.dbDriver.defaults.ssl = true;
+        }
         // for backward compatibility, allows to specify port within host
         if (config.port) {
             // but if port specified, be sure it overrides value that may be in host


### PR DESCRIPTION
This lets you set ssl: true in the config to use SSL when connecting to postgres. Needed for compatibility with heroku's security policies.