### PR TITLE
Call finishedCallback when there is an error updating the schema table

### DIFF
--- a/postgrator.js
+++ b/postgrator.js
@@ -203,6 +203,9 @@ var runMigrations = function (migrations, currentVersion, targetVersion, finishe
                 console.log('error updating the ' + config.schemaTable + ' table')
                 console.log(err)
               }
+              if (finishedCallback) {
+                finishedCallback(err, migrations)
+              }
             } else {
               // config.schemaTable successfully recorded.
               // move on to next migration


### PR DESCRIPTION
If there is an error with updating the schema table, the callback never gets called, and the migration will hang indefinitely.

This PR will call `finishedCallback` with the error, so that the user can handle it.