### PR TITLE
Allowing migration SQLs to be generated via a JS module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 .DS_Store
 .env
 .zedstate
+
+.idea/
+*.iml

--- a/postgrator.js
+++ b/postgrator.js
@@ -48,6 +48,7 @@ var getMigrations = function () {
   migrationFiles.forEach(function (file) {
     var m = file.split('.')
     var name = m.length >= 3 ? m.slice(2, m.length - 1).join('.') : file
+    var filename = config.migrationDirectory + '/' + file;
     if (m[m.length - 1] === 'sql') {
       migrations.push({
         version: Number(m[0]),
@@ -55,7 +56,24 @@ var getMigrations = function () {
         action: m[1],
         filename: file,
         name: name,
-        md5: fileChecksum(config.migrationDirectory + '/' + file, config.newline)
+        md5: fileChecksum(filename, config.newline),
+        getSql: function(){
+          return fs.readFileSync(filename, 'utf8')
+        }
+      })
+    } else if(m[m.length - 1] === 'js') {
+      var jsModule = require(filename);
+      var sql = jsModule.generateSql();
+      migrations.push({
+        version: Number(m[0]),
+        direction: m[1],
+        action: m[1],
+        filename: file,
+        name: name,
+        md5: checksum(sql, config.newline),
+        getSql: function(){
+          return sql;
+        }
       })
     }
   })
@@ -157,7 +175,7 @@ exports.getVersions = getVersions
 ================================================================= */
 var runMigrations = function (migrations, currentVersion, targetVersion, finishedCallback) {
   var runNext = function (i) {
-    var sql = fs.readFileSync((config.migrationDirectory + '/' + migrations[i].filename), 'utf8')
+    var sql = migrations[i].getSql();
     if (migrations[i].md5Sql) {
       config.logProgress && console.log('verifying checksum of migration ' + migrations[i].filename)
       runQuery(migrations[i].md5Sql, function (err, result) {

--- a/readme.md
+++ b/readme.md
@@ -17,10 +17,12 @@ migrations/
   |- 002.undo.optional-description-of-script.sql
   |- 003.do.sql
   |- 003.undo.sql
+  |- 004.do.js
+  |- 004.undo.js
   |- ... and so on
 ```
 
-The files must follow the convention [version].[action].[optional-description].sql.
+The files must follow the convention [version].[action].[optional-description].sql or  [version].[action].[optional-description].js  
 
 **Version** must be a number, but you may start and increment the numbers in any way you'd like.
 If you choose to use a purely sequential numbering scheme instead of something based off a timestamp,
@@ -29,6 +31,17 @@ you will find it helpful to start with 000s or some large number for file organi
 **Action** must be either "do" or "undo". Do implements the version, and undo undoes it.
 
 **Optional-description** can be a label or tag to help keep track of what happens inside the script. Descriptions should not contain periods.
+
+**SQL or JS**
+You have a choice of either using a plain SQL file or you can also generate your SQL via a javascript module. The javascript module should export a function called generateSql() that returns back a string representing the SQL. For example:
+   
+```javascript
+module.exports.generateSql = function () {
+  return "CREATE USER transaction_user WITH PASSWORD '"+process.env.TRANSACTION_USER_PASSWORD+"'";
+};
+```   
+
+You might want to choose the JS file approach, in order to make use (secret) environment variables such as the above.
 
 To run your sql migrations with Postgrator, write a Node.js script or integrate postgrator with your application in some way:
 

--- a/test/migrations/005.do.js
+++ b/test/migrations/005.do.js
@@ -1,7 +1,3 @@
-/*
-  using this to demo that you use environment variables to generate sql
- */
-process.env.TEST_NAME = 'aesthete';
 
 module.exports.generateSql = function () {
   return "INSERT INTO person (name, age) VALUES ('"+process.env.TEST_NAME+"', 21);"

--- a/test/migrations/005.do.js
+++ b/test/migrations/005.do.js
@@ -1,0 +1,8 @@
+/*
+  using this to demo that you use environment variables to generate sql
+ */
+process.env.TEST_NAME = 'aesthete';
+
+module.exports.generateSql = function () {
+  return "INSERT INTO person (name, age) VALUES ('"+process.env.TEST_NAME+"', 21);"
+};

--- a/test/migrations/005.undo.js
+++ b/test/migrations/005.undo.js
@@ -1,7 +1,3 @@
-/*
-  using this to demo that you use environment variables to generate sql
- */
-process.env.TEST_NAME = 'aesthete';
 
 module.exports.generateSql = function () {
   return "DELETE FROM person where name = '"+process.env.TEST_NAME+"'";

--- a/test/migrations/005.undo.js
+++ b/test/migrations/005.undo.js
@@ -1,0 +1,8 @@
+/*
+  using this to demo that you use environment variables to generate sql
+ */
+process.env.TEST_NAME = 'aesthete';
+
+module.exports.generateSql = function () {
+  return "DELETE FROM person where name = '"+process.env.TEST_NAME+"'";
+};

--- a/test/migrations/006.do.js
+++ b/test/migrations/006.do.js
@@ -1,0 +1,4 @@
+
+module.exports.generateSql = function () {
+  return "INSERT INTO person (name, age) VALUES ('"+process.env.TEST_ANOTHER_NAME+"', 21);"
+};

--- a/test/test-postgrator.js
+++ b/test/test-postgrator.js
@@ -205,15 +205,15 @@ buildTestsForConfig({
   password: 'root'
 })
 
-// buildTestsForConfig({
-//   migrationDirectory: migrationDirectory,
-//   driver: 'tedious',
-//   host: '127.0.0.1',
-//   port: 1433,
-//   database: 'Utility',
-//   username: 'sa',
-//   password: 'testuser'
-// })
+buildTestsForConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'tedious',
+  host: '127.0.0.1',
+  port: 1433,
+  database: 'Utility',
+  username: 'sa',
+  password: 'testuser'
+})
 
 /* Run the tests in an asyncy way
 ============================================================================= */

--- a/test/test-postgrator.js
+++ b/test/test-postgrator.js
@@ -87,24 +87,78 @@ var buildTestsForConfig = function (config) {
     })
   })
 
-  /* Go up to 'max' (4)
+  /* Test javascript module generated sql
+   ------------------------------------------------------------------------- */
+  tests.push(function (callback) {
+    console.log('\n----- ' + config.driver + ' up to 005 with js generated sql -----')
+    var pg = require('../postgrator.js')
+    pg.setConfig(config)
+    setTimeout(function () {
+      /*
+       using this to demo that you use environment variables to generate sql
+       */
+      process.env.TEST_NAME = 'aesthete';
+
+      pg.migrate('005', function (err, migrations) {
+        assert.ifError(err)
+        assert.ifError(err)
+        pg.runQuery('SELECT name, age FROM person', function (err, result) {
+          assert.ifError(err)
+          assert.equal(result.rows.length, 5, 'person table should have 5 records at this point')
+          assert.equal(result.rows[4].name , process.env.TEST_NAME);
+          pg.endConnection(callback)
+        })
+      })
+    }, 10000)
+  })
+
+  /* Test javascript module generated sql checksum works
+   ------------------------------------------------------------------------- */
+  tests.push(function (callback) {
+    console.log('\n----- ' + config.driver + ' up to 006 with js generated sql -----')
+    var pg = require('../postgrator.js')
+    pg.setConfig(config)
+    setTimeout(function () {
+      /*
+       using this to demo that you use environment variables to generate sql
+       */
+      process.env.TEST_ANOTHER_NAME = 'sop';
+
+      pg.migrate('006', function (err, migrations) {
+        assert.ifError(err)
+        assert.ifError(err)
+        pg.runQuery('SELECT name, age FROM person', function (err, result) {
+          assert.ifError(err)
+          assert.equal(result.rows.length, 6, 'person table should have 6 records at this point')
+          assert.equal(result.rows[4].name , process.env.TEST_NAME);
+          assert.equal(result.rows[5].name , process.env.TEST_ANOTHER_NAME);
+          pg.endConnection(callback)
+        })
+      })
+    }, 10000)
+  })
+
+  /* Go up to 'max' (6)
   ------------------------------------------------------------------------- */
   tests.push(function (callback) {
-    console.log('\n----- ' + config.driver + ' up to max (004) -----')
+    console.log('\n----- ' + config.driver + ' up to max (005) -----')
     var pg = require('../postgrator.js')
     pg.setConfig(config)
     pg.migrate('max', function (err, migrations) {
       assert.ifError(err)
       pg.runQuery('SELECT name, age FROM person', function (err, result) {
         assert.ifError(err)
-        assert.equal(result.rows.length, 4, 'person table should have 4 records at this point')
+        assert.equal(result.rows.length, 6, 'person table should have 6 records at this point')
         pg.endConnection(callback)
       })
     })
   })
 
+
+
+
   /* Go down to 0
-  ------------------------------------------------------------------------- */
+   ------------------------------------------------------------------------- */
   tests.push(function (callback) {
     console.log('\n----- ' + config.driver + ' down to 000 -----')
     var pg = require('../postgrator.js')
@@ -151,15 +205,15 @@ buildTestsForConfig({
   password: 'root'
 })
 
-buildTestsForConfig({
-  migrationDirectory: migrationDirectory,
-  driver: 'tedious',
-  host: '127.0.0.1',
-  port: 1433,
-  database: 'Utility',
-  username: 'sa',
-  password: 'testuser'
-})
+// buildTestsForConfig({
+//   migrationDirectory: migrationDirectory,
+//   driver: 'tedious',
+//   host: '127.0.0.1',
+//   port: 1433,
+//   database: 'Utility',
+//   username: 'sa',
+//   password: 'testuser'
+// })
 
 /* Run the tests in an asyncy way
 ============================================================================= */


### PR DESCRIPTION
At times, if we want to pass in secret environment variables that you can't check-in to your source repo, you need to be able to pass that into your SQL. Using sql files alone for migrations is sometimes too restrictive. This allows a lot of flexibility in SQL generation.

The JS module needs to export a method called generateSql() that returns a string representing the SQL. For example:

```javascript
module.exports.generateSql = function () {
  return "CREATE USER transaction_user WITH PASSWORD '"+process.env.TRANSACTION_USER_PASSWORD+"'";
};
```

That's one example of where generating SQL might help. There might other instances as well. Tools such as flyway allow you to specify SQL as well as java files that do DB operations as a part of the migration. This change will allow postgrator to do the same.
