### PR TITLE
Updated to match new query result format

### DIFF
--- a/lib/create-common-client.js
+++ b/lib/create-common-client.js
@@ -125,7 +125,7 @@ module.exports = function (config) {
       var runBatch = function (batchIndex) {
         request.batch(batches[batchIndex], function (err, result) {
           if (err || batchIndex === batches.length - 1) {
-            cb(err, {rows: result})
+            cb(err, {rows: result.recordset ? result.recordset : result})
           } else {
             runBatch(batchIndex + 1)
           }


### PR DESCRIPTION
Result object coming back from mssql returns a full object with other metadata. I believe you want result.recordset. I left in a check so previous Result object formats will work.