### PR TITLE
Add migrations to versions object

### DIFF
--- a/postgrator.js
+++ b/postgrator.js
@@ -146,6 +146,7 @@ var getVersions = function (callback) {
   var versions = {}
   getMigrations()
   versions.max = Math.max.apply(null, migrations.map(function (migration) { return migration.version }).filter(function(version){ return !isNaN(version) }) )
+  versions.migrations = migrations;
   getCurrentVersion(function (err, version) {
     if (err) {
       if (config.logProgress) {

--- a/postgrator.js
+++ b/postgrator.js
@@ -145,8 +145,8 @@ exports.getCurrentVersion = getCurrentVersion
 var getVersions = function (callback) {
   var versions = {}
   getMigrations()
-  versions.max = Math.max.apply(null, migrations.map(function (migration) { return migration.version }).filter(function(version){ return !isNaN(version) }) )
-  versions.migrations = migrations;
+  versions.migrations = migrations.map(function (migration) { return migration.version }).filter(function(version){ return !isNaN(version) })
+  versions.max = Math.max.apply(null, versions.migrations)
   getCurrentVersion(function (err, version) {
     if (err) {
       if (config.logProgress) {


### PR DESCRIPTION
Easiest way to expose all available migrations. Would allow `getVersions()` to return all available information about the migration scripts with one call. 