### PR TITLE
Version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,88 @@
+# CHANGELOG
+
+## 3.0.0
+### In development
+
+#### Features / Improvements
+- `run_at` timestamp column added to schema table
+- `md5` and `name` columns added for all implementations
+- Checksum validation now implemented for all drivers
+- Checksum validation may be skipped using config `validateChecksums: false`
+- Callback API replaced with Promises
+- Connections opened/closed automatically (no more `.endConnection()`)
+- Lots of tests
+
+#### Breaking changes
+- Node 6 or greater now required
+- DB drivers must be installed prior to use (`pg`, `mysql`, `mssql`)
+- `pg.js` and `tedious` no longer valid driver config option
+- None of the API is the same
+- Checksums now validated by default for all drivers
+- Calling `.migrate()` without input migrates to latest/max
+- Logging to console removed
+
+## 2.10.0
+### May 6 2017
+
+- Allow migration SQL to be generated via js function
+
+## 2.9.0
+### Apr 6 2017
+
+- Added postgres ssl support
+
+## 2.8.0
+### Apr 26 2016
+
+- Allow port configuration
+
+## 2.6.0
+### Jan 20 2016
+
+- Added config to toggle logging progress
+- Added config for requestTimeout
+- Added support for mssql batches using GO keyword
+
+## 2.5.0
+### Aug 25 2015
+
+- Exposed functions to get current/max migration versions
+
+## 2.4.0
+### Aug 19 2015
+
+- Added config for schematable name
+- Added config for checksum newline ending normalization
+
+## 2.3.0
+### June 15 2015
+
+- Version column increased to BIGINT
+
+## 2.2.0
+### Apr 30 2015
+
+- SQL Server connections closed with endConnection()
+- Update db driver modules
+
+## 2.1.0
+### Feb 7 2015
+
+- Update mssql config: timeout set to 1 hour
+- Add version as PK on schemaversion table
+
+## 2.0.0
+### Nov 20 2014
+
+- Checksum validation added for postgres
+- postgrator.migrate('max', cb) added to migrate to latest version
+
+## 1.x
+### Nov 6 2014
+
+Initial version released
+
+## 0.x
+### Dec 12 2012
+
+Initial development

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-#The MIT License
+MIT License
 
 Copyright (c) 2012 Rick Bergfalk
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,11 @@ services:
     ports:
       - "3306:3306"
   # SQL Server needs 3.25 GB of RAM
-  sqlserver:
-    image: microsoft/mssql-server-linux:latest
-    environment:
-      ACCEPT_EULA: Y 
-      SA_PASSWORD: Postgrator123!
-      MSSQL_PID: Express
-    ports:
-      - "1433:1433"
+  # sqlserver:
+  #   image: microsoft/mssql-server-linux:latest
+  #   environment:
+  #     ACCEPT_EULA: Y 
+  #     SA_PASSWORD: Postgrator123!
+  #     MSSQL_PID: Express
+  #   ports:
+  #     - "1433:1433"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,12 @@ services:
       MYSQL_PASSWORD: postgrator
     ports:
       - "3306:3306"
-  # SQL Server needs 3.25 GB of RAM and for some reason doesn't download...
-  # sqlserver:
-  #   image: microsoft/mssql-server-linux:latest
-  #   environment:
-  #     ACCEPT_EULA: Y 
-  #     SA_PASSWORD: Postgrator123!
-  #     MSSQL_PID: Express
-  #   ports:
-  #     - "1433:1433"
+  # SQL Server needs 3.25 GB of RAM
+  sqlserver:
+    image: microsoft/mssql-server-linux:latest
+    environment:
+      ACCEPT_EULA: Y 
+      SA_PASSWORD: Postgrator123!
+      MSSQL_PID: Express
+    ports:
+      - "1433:1433"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,12 @@ services:
       MYSQL_PASSWORD: postgrator
     ports:
       - "3306:3306"
+  # SQL Server needs 3.25 GB of RAM and for some reason doesn't download...
+  # sqlserver:
+  #   image: microsoft/mssql-server-linux:latest
+  #   environment:
+  #     ACCEPT_EULA: Y 
+  #     SA_PASSWORD: Postgrator123!
+  #     MSSQL_PID: Express
+  #   ports:
+  #     - "1433:1433"

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
     runQuery: Promise.resolve(),
     endConnection: Promise.resolve(),
     queries: {
-      getCurrentVersion: `
+      getDatabaseVersion: `
         SELECT version 
         FROM ${config.schemaTable} 
         ORDER BY version DESC 
@@ -224,7 +224,7 @@ function createMssql(config, commonClient) {
     requestTimeout: config.requestTimeout || oneHour
   }
 
-  commonClient.queries.getCurrentVersion = `
+  commonClient.queries.getDatabaseVersion = `
     SELECT TOP 1 version 
     FROM ${config.schemaTable} 
     ORDER BY version DESC`

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -11,7 +11,6 @@ module.exports = function(config) {
     connected: false,
     dbDriver: null,
     dbConnection: null,
-    schemaTable: config.schemaTable,
     createConnection: Promise.resolve(),
     runQuery: Promise.resolve(),
     endConnection: Promise.resolve(),
@@ -27,178 +26,212 @@ module.exports = function(config) {
   }
 
   if (config.driver === 'mysql') {
-    try {
-      commonClient.dbDriver = require('mysql')
-    } catch (e) {
-      console.error('Did you forget to run "npm install mysql"?')
-      throw e
-    }
-
-    commonClient.queries.checkTable = `
-      SELECT * 
-      FROM information_schema.tables 
-      WHERE table_schema = '${config.database}' 
-      AND table_name = '${config.schemaTable}';`
-
-    commonClient.queries.makeTable = `
-      CREATE TABLE ${config.schemaTable} (
-        version BIGINT, 
-        PRIMARY KEY (version)
-      ); 
-      INSERT INTO ${config.schemaTable} (version) 
-        VALUES (0);`
-
-    commonClient.createConnection = () => {
-      return new Promise((resolve, reject) => {
-        const connection = commonClient.dbDriver.createConnection({
-          multipleStatements: true,
-          host: config.host,
-          port: config.port,
-          user: config.username,
-          password: config.password,
-          database: config.database
-        })
-        commonClient.dbConnection = connection
-        connection.connect(err => {
-          if (err) return reject(err)
-          resolve()
-        })
-      })
-    }
-
-    commonClient.runQuery = query => {
-      return new Promise((resolve, reject) => {
-        commonClient.dbConnection.query(query, (err, rows, fields) => {
-          if (err) {
-            return reject(err)
-          }
-          const results = {}
-          if (rows) results.rows = rows
-          if (fields) results.fields = fields
-          resolve(results)
-        })
-      })
-    }
-
-    commonClient.endConnection = () => {
-      return new Promise((resolve, reject) => {
-        commonClient.dbConnection.end(err => {
-          if (err) return reject(err)
-          resolve()
-        })
-      })
-    }
+    createMysql(config, commonClient)
   } else if (config.driver === 'pg') {
-    try {
-      commonClient.dbDriver = require('pg')
-    } catch (e) {
-      console.error('Did you forget to run "npm install pg"?')
-      throw e
-    }
-    if (config.ssl) {
-      commonClient.dbDriver.defaults.ssl = true
-    }
-
-    commonClient.queries.checkTable = `
-      SELECT * 
-      FROM pg_catalog.pg_tables 
-      WHERE schemaname = CURRENT_SCHEMA 
-      AND tablename = '${config.schemaTable}';`
-
-    commonClient.queries.makeTable = `
-      CREATE TABLE ${config.schemaTable} (
-        version BIGINT PRIMARY KEY, 
-        name TEXT DEFAULT '', 
-        md5 TEXT DEFAULT ''
-      ); 
-      INSERT INTO ${config.schemaTable} (version, name, md5) 
-        VALUES (0, '', '');`
-
-    commonClient.createConnection = () => {
-      if (config.username) {
-        config.user = config.username
-      }
-      commonClient.dbConnection = new commonClient.dbDriver.Client(
-        config.connectionString || config
-      )
-      return commonClient.dbConnection.connect()
-    }
-
-    commonClient.runQuery = query => commonClient.dbConnection.query(query)
-
-    commonClient.endConnection = () => commonClient.dbConnection.end()
+    createPostgres(config, commonClient)
   } else if (config.driver === 'mssql') {
-    try {
-      commonClient.dbDriver = require('mssql')
-    } catch (e) {
-      console.error('Did you forget to run "npm install mssql"?')
-      throw e
-    }
+    createMssql(config, commonClient)
+  }
 
-    const oneHour = 1000 * 60 * 60
-
-    const sqlconfig = {
-      user: config.username,
-      password: config.password,
-      server: config.host,
-      port: config.port,
-      database: config.database,
-      options: config.options,
-      requestTimeout: config.requestTimeout || oneHour
-    }
-
-    commonClient.queries.getCurrentVersion = `
-      SELECT TOP 1 version 
-      FROM ${config.schemaTable} 
-      ORDER BY version DESC`
-
-    commonClient.queries.checkTable = `
-      SELECT * 
-      FROM information_schema.tables 
-      WHERE table_schema = 'dbo' 
-      AND table_name = '${config.schemaTable}'`
-
-    commonClient.queries.makeTable = `
-      CREATE TABLE ${config.schemaTable} (
-        version BIGINT PRIMARY KEY
-      ); 
-      INSERT INTO ${config.schemaTable} (version) 
-        VALUES (0);`
-
-    commonClient.createConnection = cb => {
-      return commonClient.dbDriver.connect(sqlconfig).then(connection => {
-        commonClient.dbConnection = connection
+  commonClient.runQuery = query => {
+    if (commonClient.connected) {
+      return commonClient._runQuery(query)
+    } else {
+      return commonClient._createConnection().then(() => {
+        commonClient.connected = true
+        return commonClient._runQuery(query)
       })
-    }
-
-    commonClient.runQuery = query => {
-      return new Promise((resolve, reject) => {
-        const request = new commonClient.dbDriver.Request()
-        const batches = query.split(/^\s*GO\s*$/im)
-
-        function runBatch(batchIndex) {
-          request.batch(batches[batchIndex], (err, result) => {
-            if (err) {
-              return reject(err)
-            }
-            if (batchIndex === batches.length - 1) {
-              return resolve({
-                rows: result && result.recordset ? result.recordset : result
-              })
-            }
-            return runBatch(batchIndex + 1)
-          })
-        }
-
-        runBatch(0)
-      })
-    }
-
-    commonClient.endConnection = () => {
-      commonClient.dbConnection.close()
-      return Promise.resolve()
     }
   }
 
+  commonClient.endConnection = () => {
+    if (commonClient.connected) {
+      return commonClient._endConnection().then(() => {
+        commonClient.connected = false
+      })
+    }
+    return Promise.resolve()
+  }
+
   return commonClient
+}
+
+function createMysql(config, commonClient) {
+  try {
+    commonClient.dbDriver = require('mysql')
+  } catch (e) {
+    console.error('Did you forget to run "npm install mysql"?')
+    throw e
+  }
+
+  commonClient.queries.checkTable = `
+    SELECT * 
+    FROM information_schema.tables 
+    WHERE table_schema = '${config.database}' 
+    AND table_name = '${config.schemaTable}';`
+
+  commonClient.queries.makeTable = `
+    CREATE TABLE ${config.schemaTable} (
+      version BIGINT, 
+      PRIMARY KEY (version)
+    ); 
+    INSERT INTO ${config.schemaTable} (version) 
+      VALUES (0);`
+
+  commonClient._createConnection = () => {
+    return new Promise((resolve, reject) => {
+      const connection = commonClient.dbDriver.createConnection({
+        multipleStatements: true,
+        host: config.host,
+        port: config.port,
+        user: config.username,
+        password: config.password,
+        database: config.database
+      })
+      commonClient.dbConnection = connection
+      connection.connect(err => {
+        if (err) return reject(err)
+        resolve()
+      })
+    })
+  }
+
+  commonClient._runQuery = query => {
+    return new Promise((resolve, reject) => {
+      commonClient.dbConnection.query(query, (err, rows, fields) => {
+        if (err) {
+          return reject(err)
+        }
+        const results = {}
+        if (rows) results.rows = rows
+        if (fields) results.fields = fields
+        resolve(results)
+      })
+    })
+  }
+
+  commonClient._endConnection = () => {
+    return new Promise((resolve, reject) => {
+      commonClient.dbConnection.end(err => {
+        if (err) return reject(err)
+        resolve()
+      })
+    })
+  }
+
+  return commonClient
+}
+
+function createPostgres(config, commonClient) {
+  try {
+    commonClient.dbDriver = require('pg')
+  } catch (e) {
+    console.error('Did you forget to run "npm install pg"?')
+    throw e
+  }
+  if (config.ssl) {
+    commonClient.dbDriver.defaults.ssl = true
+  }
+
+  commonClient.queries.checkTable = `
+    SELECT * 
+    FROM pg_catalog.pg_tables 
+    WHERE schemaname = CURRENT_SCHEMA 
+    AND tablename = '${config.schemaTable}';`
+
+  commonClient.queries.makeTable = `
+    CREATE TABLE ${config.schemaTable} (
+      version BIGINT PRIMARY KEY, 
+      name TEXT DEFAULT '', 
+      md5 TEXT DEFAULT ''
+    ); 
+    INSERT INTO ${config.schemaTable} (version, name, md5) 
+      VALUES (0, '', '');`
+
+  commonClient._createConnection = () => {
+    if (config.username) {
+      config.user = config.username
+    }
+    commonClient.dbConnection = new commonClient.dbDriver.Client(
+      config.connectionString || config
+    )
+    return commonClient.dbConnection.connect()
+  }
+
+  commonClient._runQuery = query => commonClient.dbConnection.query(query)
+
+  commonClient._endConnection = () => commonClient.dbConnection.end()
+}
+
+function createMssql(config, commonClient) {
+  try {
+    commonClient.dbDriver = require('mssql')
+  } catch (e) {
+    console.error('Did you forget to run "npm install mssql"?')
+    throw e
+  }
+
+  const oneHour = 1000 * 60 * 60
+
+  const sqlconfig = {
+    user: config.username,
+    password: config.password,
+    server: config.host,
+    port: config.port,
+    database: config.database,
+    options: config.options,
+    requestTimeout: config.requestTimeout || oneHour
+  }
+
+  commonClient.queries.getCurrentVersion = `
+    SELECT TOP 1 version 
+    FROM ${config.schemaTable} 
+    ORDER BY version DESC`
+
+  commonClient.queries.checkTable = `
+    SELECT * 
+    FROM information_schema.tables 
+    WHERE table_schema = 'dbo' 
+    AND table_name = '${config.schemaTable}'`
+
+  commonClient.queries.makeTable = `
+    CREATE TABLE ${config.schemaTable} (
+      version BIGINT PRIMARY KEY
+    ); 
+    INSERT INTO ${config.schemaTable} (version) 
+      VALUES (0);`
+
+  commonClient._createConnection = () => {
+    return commonClient.dbDriver.connect(sqlconfig).then(connection => {
+      commonClient.dbConnection = connection
+    })
+  }
+
+  commonClient._runQuery = query => {
+    return new Promise((resolve, reject) => {
+      const request = new commonClient.dbDriver.Request()
+      const batches = query.split(/^\s*GO\s*$/im)
+
+      function runBatch(batchIndex) {
+        request.batch(batches[batchIndex], (err, result) => {
+          if (err) {
+            return reject(err)
+          }
+          if (batchIndex === batches.length - 1) {
+            return resolve({
+              rows: result && result.recordset ? result.recordset : result
+            })
+          }
+          return runBatch(batchIndex + 1)
+        })
+      }
+
+      runBatch(0)
+    })
+  }
+
+  commonClient._endConnection = () => {
+    commonClient.dbConnection.close()
+    return Promise.resolve()
+  }
 }

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -12,13 +12,15 @@ module.exports = function(config) {
     dbDriver: null,
     dbConnection: null,
     schemaTable: config.schemaTable,
-    createConnection: () => {},
-    runQuery: (query, cb) => cb(),
-    endConnection: cb => cb(),
+    createConnection: Promise.resolve(),
+    runQuery: Promise.resolve(),
+    endConnection: Promise.resolve(),
     queries: {
-      getCurrentVersion: `SELECT version FROM ${
-        config.schemaTable
-      } ORDER BY version DESC LIMIT 1`,
+      getCurrentVersion: `
+        SELECT version 
+        FROM ${config.schemaTable} 
+        ORDER BY version DESC 
+        LIMIT 1`,
       checkTable: '',
       makeTable: ''
     }
@@ -46,34 +48,45 @@ module.exports = function(config) {
       INSERT INTO ${config.schemaTable} (version) 
         VALUES (0);`
 
-    commonClient.createConnection = function(cb) {
-      const connection = commonClient.dbDriver.createConnection({
-        multipleStatements: true,
-        host: config.host,
-        port: config.port,
-        user: config.username,
-        password: config.password,
-        database: config.database
+    commonClient.createConnection = () => {
+      return new Promise((resolve, reject) => {
+        const connection = commonClient.dbDriver.createConnection({
+          multipleStatements: true,
+          host: config.host,
+          port: config.port,
+          user: config.username,
+          password: config.password,
+          database: config.database
+        })
+        commonClient.dbConnection = connection
+        connection.connect(err => {
+          if (err) return reject(err)
+          resolve()
+        })
       })
-      commonClient.dbConnection = connection
-      connection.connect(cb)
     }
 
-    commonClient.runQuery = function(query, cb) {
-      commonClient.dbConnection.query(query, function(err, rows, fields) {
-        if (err) {
-          cb(err)
-        } else {
+    commonClient.runQuery = query => {
+      return new Promise((resolve, reject) => {
+        commonClient.dbConnection.query(query, (err, rows, fields) => {
+          if (err) {
+            return reject(err)
+          }
           const results = {}
           if (rows) results.rows = rows
           if (fields) results.fields = fields
-          cb(err, results)
-        }
+          resolve(results)
+        })
       })
     }
 
-    commonClient.endConnection = function(cb) {
-      commonClient.dbConnection.end(cb)
+    commonClient.endConnection = () => {
+      return new Promise((resolve, reject) => {
+        commonClient.dbConnection.end(err => {
+          if (err) return reject(err)
+          resolve()
+        })
+      })
     }
   } else if (config.driver === 'pg') {
     try {
@@ -101,26 +114,19 @@ module.exports = function(config) {
       INSERT INTO ${config.schemaTable} (version, name, md5) 
         VALUES (0, '', '');`
 
-    commonClient.createConnection = function(cb) {
+    commonClient.createConnection = () => {
       if (config.username) {
         config.user = config.username
       }
       commonClient.dbConnection = new commonClient.dbDriver.Client(
         config.connectionString || config
       )
-      commonClient.dbConnection.connect(cb)
+      return commonClient.dbConnection.connect()
     }
 
-    commonClient.runQuery = function(query, cb) {
-      commonClient.dbConnection.query(query, function(err, result) {
-        cb(err, result)
-      })
-    }
+    commonClient.runQuery = query => commonClient.dbConnection.query(query)
 
-    commonClient.endConnection = function(cb) {
-      commonClient.dbConnection.end()
-      process.nextTick(cb)
-    }
+    commonClient.endConnection = () => commonClient.dbConnection.end()
   } else if (config.driver === 'mssql') {
     try {
       commonClient.dbDriver = require('mssql')
@@ -159,32 +165,38 @@ module.exports = function(config) {
       INSERT INTO ${config.schemaTable} (version) 
         VALUES (0);`
 
-    commonClient.createConnection = function(cb) {
-      commonClient.dbConnection = commonClient.dbDriver.connect(sqlconfig, cb)
+    commonClient.createConnection = cb => {
+      return commonClient.dbDriver.connect(sqlconfig).then(connection => {
+        commonClient.dbConnection = connection
+      })
     }
 
-    commonClient.runQuery = function(query, cb) {
-      const request = new commonClient.dbDriver.Request()
-      const batches = query.split(/^\s*GO\s*$/im)
+    commonClient.runQuery = query => {
+      return new Promise((resolve, reject) => {
+        const request = new commonClient.dbDriver.Request()
+        const batches = query.split(/^\s*GO\s*$/im)
 
-      function runBatch(batchIndex) {
-        request.batch(batches[batchIndex], function(err, result) {
-          if (err || batchIndex === batches.length - 1) {
-            cb(err, {
-              rows: result && result.recordset ? result.recordset : result
-            })
-          } else {
-            runBatch(batchIndex + 1)
-          }
-        })
-      }
+        function runBatch(batchIndex) {
+          request.batch(batches[batchIndex], (err, result) => {
+            if (err) {
+              return reject(err)
+            }
+            if (batchIndex === batches.length - 1) {
+              return resolve({
+                rows: result && result.recordset ? result.recordset : result
+              })
+            }
+            return runBatch(batchIndex + 1)
+          })
+        }
 
-      runBatch(0)
+        runBatch(0)
+      })
     }
 
-    commonClient.endConnection = function(cb) {
+    commonClient.endConnection = () => {
       commonClient.dbConnection.close()
-      cb()
+      return Promise.resolve()
     }
   }
 

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -102,19 +102,24 @@ module.exports = function(config) {
         `)
       }
       const textType = config.driver === 'mssql' ? 'VARCHAR(32)' : 'TEXT'
+      const columnKeyword = config.driver === 'mssql' ? '' : 'COLUMN'
       if (!results.rows.find(row => row.column_name === 'name')) {
         sqls.push(
-          `ALTER TABLE ${config.schemaTable} ADD COLUMN name ${textType};`
+          `ALTER TABLE ${config.schemaTable} ADD ${columnKeyword} name ${
+            textType
+          };`
         )
       }
       if (!results.rows.find(row => row.column_name === 'md5')) {
         sqls.push(
-          `ALTER TABLE ${config.schemaTable} ADD COLUMN md5 ${textType};`
+          `ALTER TABLE ${config.schemaTable} ADD ${columnKeyword} md5 ${
+            textType
+          };`
         )
       }
       if (!results.rows.find(row => row.column_name === 'run_at')) {
         sqls.push(
-          `ALTER TABLE ${config.schemaTable} ADD COLUMN run_at ${
+          `ALTER TABLE ${config.schemaTable} ADD ${columnKeyword} run_at ${
             TIMESTAMP_TYPES[config.driver]
           };`
         )
@@ -234,14 +239,17 @@ function createMssql(config, commonClient) {
     ORDER BY version DESC`
 
   commonClient._createConnection = () => {
-    return commonClient.dbDriver.connect(sqlconfig).then(connection => {
-      commonClient.dbConnection = connection
-    })
+    commonClient.dbConnection = new commonClient.dbDriver.ConnectionPool(
+      sqlconfig
+    )
+    return commonClient.dbConnection.connect()
   }
 
   commonClient._runQuery = query => {
     return new Promise((resolve, reject) => {
-      const request = new commonClient.dbDriver.Request()
+      const request = new commonClient.dbDriver.Request(
+        commonClient.dbConnection
+      )
       const batches = query.split(/^\s*GO\s*$/im)
 
       function runBatch(batchIndex) {

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -53,21 +53,33 @@ module.exports = function(config) {
     return Promise.resolve()
   }
 
-  commonClient.ensureColumn = (name, type) => {
+  commonClient.ensureTable = () => {
     const sql = `
       SELECT column_name
       FROM INFORMATION_SCHEMA.COLUMNS 
-      WHERE table_name = '${config.schemaTable}' 
-      AND column_name = '${name}';
+      WHERE table_name = '${config.schemaTable}';
     `
     return commonClient.runQuery(sql).then(results => {
-      if (results.rows && results.rows.length) {
-        return
+      const sqls = []
+      if (results.rows.length === 0) {
+        sqls.push(commonClient.queries.makeTable)
       }
-      const alterSql = `
-        ALTER TABLE ${config.schemaTable} ADD COLUMN ${name} ${type};
-      `
-      return commonClient.runQuery(alterSql)
+      const textType = config.driver === 'mssql' ? 'VARCHAR(32)' : 'TEXT'
+      if (!results.rows.find(row => row.column_name === 'name')) {
+        sqls.push(
+          `ALTER TABLE ${config.schemaTable} ADD COLUMN name ${textType};`
+        )
+      }
+      if (!results.rows.find(row => row.column_name === 'md5')) {
+        sqls.push(
+          `ALTER TABLE ${config.schemaTable} ADD COLUMN md5 ${textType};`
+        )
+      }
+      let sequence = Promise.resolve()
+      sqls.forEach(sql => {
+        sequence = sequence.then(() => commonClient.runQuery(sql))
+      })
+      return sequence
     })
   }
 
@@ -159,12 +171,10 @@ function createPostgres(config, commonClient) {
 
   commonClient.queries.makeTable = `
     CREATE TABLE ${config.schemaTable} (
-      version BIGINT PRIMARY KEY, 
-      name TEXT DEFAULT '', 
-      md5 TEXT DEFAULT ''
+      version BIGINT PRIMARY KEY
     ); 
-    INSERT INTO ${config.schemaTable} (version, name, md5) 
-      VALUES (0, '', '');`
+    INSERT INTO ${config.schemaTable} (version) 
+      VALUES (0);`
 
   commonClient._createConnection = () => {
     if (config.username) {

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -230,7 +230,11 @@ function createMssql(config, commonClient) {
     port: config.port,
     database: config.database,
     options: config.options,
-    requestTimeout: config.requestTimeout || oneHour
+    requestTimeout: config.requestTimeout || oneHour,
+    pool: {
+      max: 1,
+      min: 1
+    }
   }
 
   commonClient.queries.getDatabaseVersion = `

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -20,6 +20,28 @@ module.exports = function(config) {
     createConnection: Promise.resolve(),
     runQuery: Promise.resolve(),
     endConnection: Promise.resolve(),
+    persistActionSql: migration => {
+      const action = migration.action.toLowerCase()
+      if (action === 'do') {
+        return `
+          INSERT INTO ${config.schemaTable} (version, name, md5, run_at) 
+          VALUES (
+            ${migration.version}, 
+            '${migration.name}', 
+            '${migration.md5}',
+            '${new Date()
+              .toISOString()
+              .replace('T', ' ')
+              .replace('Z', '')}'
+          );`
+      }
+      if (action === 'undo') {
+        return `
+          DELETE FROM ${config.schemaTable} 
+          WHERE version = ${migration.version};`
+      }
+      throw new Error('unknown migration action')
+    },
     queries: {
       getDatabaseVersion: `
         SELECT version 

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -1,9 +1,15 @@
-const supportedDrivers = ['pg', 'mysql', 'mssql']
+const DRIVERS = ['pg', 'mysql', 'mssql']
+
+const TIMESTAMP_TYPES = {
+  pg: 'TIMESTAMP WITH TIME ZONE',
+  mysql: 'TIMESTAMP',
+  mssql: 'DATETIME'
+}
 
 module.exports = function(config) {
-  if (supportedDrivers.indexOf(config.driver) === -1) {
+  if (DRIVERS.indexOf(config.driver) === -1) {
     throw new Error(
-      'db driver not supported. Must one of: ' + supportedDrivers.join(', ')
+      'db driver not supported. Must one of: ' + DRIVERS.join(', ')
     )
   }
 
@@ -73,6 +79,13 @@ module.exports = function(config) {
       if (!results.rows.find(row => row.column_name === 'md5')) {
         sqls.push(
           `ALTER TABLE ${config.schemaTable} ADD COLUMN md5 ${textType};`
+        )
+      }
+      if (!results.rows.find(row => row.column_name === 'run_at')) {
+        sqls.push(
+          `ALTER TABLE ${config.schemaTable} ADD COLUMN run_at ${
+            TIMESTAMP_TYPES[config.driver]
+          };`
         )
       }
       let sequence = Promise.resolve()

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -53,6 +53,24 @@ module.exports = function(config) {
     return Promise.resolve()
   }
 
+  commonClient.ensureColumn = (name, type) => {
+    const sql = `
+      SELECT column_name
+      FROM INFORMATION_SCHEMA.COLUMNS 
+      WHERE table_name = '${config.schemaTable}' 
+      AND column_name = '${name}';
+    `
+    return commonClient.runQuery(sql).then(results => {
+      if (results.rows && results.rows.length) {
+        return
+      }
+      const alterSql = `
+        ALTER TABLE ${config.schemaTable} ADD COLUMN ${name} ${type};
+      `
+      return commonClient.runQuery(alterSql)
+    })
+  }
+
   return commonClient
 }
 

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -17,9 +17,9 @@ module.exports = function(config) {
     connected: false,
     dbDriver: null,
     dbConnection: null,
-    createConnection: Promise.resolve(),
-    runQuery: Promise.resolve(),
-    endConnection: Promise.resolve(),
+    createConnection: () => Promise.resolve(),
+    runQuery: () => Promise.resolve(),
+    endConnection: () => Promise.resolve(),
     persistActionSql: migration => {
       const action = migration.action.toLowerCase()
       if (action === 'do') {
@@ -43,6 +43,11 @@ module.exports = function(config) {
       throw new Error('unknown migration action')
     },
     queries: {
+      getMd5: migration => `
+        SELECT md5 
+        FROM ${config.schemaTable} 
+        WHERE version = ${migration.version};
+      `,
       getDatabaseVersion: `
         SELECT version 
         FROM ${config.schemaTable} 

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -53,7 +53,6 @@ module.exports = function(config) {
         FROM ${config.schemaTable} 
         ORDER BY version DESC 
         LIMIT 1`,
-      checkTable: '',
       makeTable: ''
     }
   }
@@ -134,12 +133,6 @@ function createMysql(config, commonClient) {
     throw e
   }
 
-  commonClient.queries.checkTable = `
-    SELECT * 
-    FROM information_schema.tables 
-    WHERE table_schema = '${config.database}' 
-    AND table_name = '${config.schemaTable}';`
-
   commonClient.queries.makeTable = `
     CREATE TABLE ${config.schemaTable} (
       version BIGINT, 
@@ -203,12 +196,6 @@ function createPostgres(config, commonClient) {
     commonClient.dbDriver.defaults.ssl = true
   }
 
-  commonClient.queries.checkTable = `
-    SELECT * 
-    FROM pg_catalog.pg_tables 
-    WHERE schemaname = CURRENT_SCHEMA 
-    AND tablename = '${config.schemaTable}';`
-
   commonClient.queries.makeTable = `
     CREATE TABLE ${config.schemaTable} (
       version BIGINT PRIMARY KEY
@@ -255,12 +242,6 @@ function createMssql(config, commonClient) {
     SELECT TOP 1 version 
     FROM ${config.schemaTable} 
     ORDER BY version DESC`
-
-  commonClient.queries.checkTable = `
-    SELECT * 
-    FROM information_schema.tables 
-    WHERE table_schema = 'dbo' 
-    AND table_name = '${config.schemaTable}'`
 
   commonClient.queries.makeTable = `
     CREATE TABLE ${config.schemaTable} (

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -52,8 +52,7 @@ module.exports = function(config) {
         SELECT version 
         FROM ${config.schemaTable} 
         ORDER BY version DESC 
-        LIMIT 1`,
-      makeTable: ''
+        LIMIT 1`
     }
   }
 
@@ -94,7 +93,13 @@ module.exports = function(config) {
     return commonClient.runQuery(sql).then(results => {
       const sqls = []
       if (results.rows.length === 0) {
-        sqls.push(commonClient.queries.makeTable)
+        sqls.push(`
+          CREATE TABLE ${config.schemaTable} (
+            version BIGINT PRIMARY KEY
+          ); 
+          INSERT INTO ${config.schemaTable} (version) 
+            VALUES (0);
+        `)
       }
       const textType = config.driver === 'mssql' ? 'VARCHAR(32)' : 'TEXT'
       if (!results.rows.find(row => row.column_name === 'name')) {
@@ -132,14 +137,6 @@ function createMysql(config, commonClient) {
     console.error('Did you forget to run "npm install mysql"?')
     throw e
   }
-
-  commonClient.queries.makeTable = `
-    CREATE TABLE ${config.schemaTable} (
-      version BIGINT, 
-      PRIMARY KEY (version)
-    ); 
-    INSERT INTO ${config.schemaTable} (version) 
-      VALUES (0);`
 
   commonClient._createConnection = () => {
     return new Promise((resolve, reject) => {
@@ -196,13 +193,6 @@ function createPostgres(config, commonClient) {
     commonClient.dbDriver.defaults.ssl = true
   }
 
-  commonClient.queries.makeTable = `
-    CREATE TABLE ${config.schemaTable} (
-      version BIGINT PRIMARY KEY
-    ); 
-    INSERT INTO ${config.schemaTable} (version) 
-      VALUES (0);`
-
   commonClient._createConnection = () => {
     if (config.username) {
       config.user = config.username
@@ -242,13 +232,6 @@ function createMssql(config, commonClient) {
     SELECT TOP 1 version 
     FROM ${config.schemaTable} 
     ORDER BY version DESC`
-
-  commonClient.queries.makeTable = `
-    CREATE TABLE ${config.schemaTable} (
-      version BIGINT PRIMARY KEY
-    ); 
-    INSERT INTO ${config.schemaTable} (version) 
-      VALUES (0);`
 
   commonClient._createConnection = () => {
     return commonClient.dbDriver.connect(sqlconfig).then(connection => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "author": "Rick Bergfalk <rick.bergfalk@gmail.com>",
   "description": "Postgrator is a SQL migration tool for SQL people",
   "license": "MIT",
-  "engines": { "node": ">=6.0.0" },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "keywords": [
     "migrator",
     "migration",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "2.10.3",
   "author": "Rick Bergfalk <rick.bergfalk@gmail.com>",
   "description": "Postgrator is a SQL migration tool for SQL people",
+  "license": "MIT",
+  "engines": { "node": ">=6.0.0" },
   "keywords": [
     "migrator",
     "migration",

--- a/postgrator.js
+++ b/postgrator.js
@@ -240,7 +240,6 @@ Postgrator.prototype.getRelevantMigrations = function getRelevantMigrations(
  *
  * @returns {Promise}
  * @param {*} target - version to migrate as string or number (handled as  numbers internally)
-
  */
 Postgrator.prototype.migrate = function(target = '') {
   return this.prep()

--- a/postgrator.js
+++ b/postgrator.js
@@ -25,8 +25,6 @@ class Postgrator extends EventEmitter {
 
   /**
    * Reads all migrations from directory
-   * Returns promise of array of objects in format:
-   * {version: n, action: 'do', filename: '0001.up.sql'}
    *
    * @returns {Promise} array of migration objects
    */

--- a/postgrator.js
+++ b/postgrator.js
@@ -243,7 +243,8 @@ class Postgrator {
    */
   migrate(target = '') {
     const data = {}
-    return this.prep()
+    return this.commonClient
+      .ensureTable()
       .then(() => this.getMigrations())
       .then(() => {
         const cleaned = target.toLowerCase().trim()
@@ -271,26 +272,6 @@ class Postgrator {
       .then(migrations =>
         this.commonClient.endConnection().then(() => migrations)
       )
-  }
-
-  /**
-   * Creates the table required for Postgrator to keep track of which migrations have been run.
-   *
-   * @returns {Promise}
-   */
-  prep() {
-    const { commonClient } = this
-    return commonClient
-      .runQuery(commonClient.queries.checkTable)
-      .then(result => {
-        if (result.rows && result.rows.length > 0) {
-          return commonClient
-            .ensureColumn('name', 'text')
-            .then(() => commonClient.ensureColumn('md5', 'text'))
-        } else {
-          return commonClient.runQuery(commonClient.queries.makeTable)
-        }
-      })
   }
 }
 

--- a/postgrator.js
+++ b/postgrator.js
@@ -211,7 +211,7 @@ class Postgrator {
    * @param {Number} currentVersion
    * @param {Number} targetVersion
    */
-  getRelevantMigrations(currentVersion, targetVersion) {
+  getRunnableMigrations(currentVersion, targetVersion) {
     const { config, migrations } = this
     if (targetVersion >= currentVersion) {
       return migrations
@@ -285,13 +285,9 @@ class Postgrator {
         this.validateMigrations(data.currentVersion, data.targetVersion)
       )
       .then(() =>
-        this.getRelevantMigrations(data.currentVersion, data.targetVersion)
+        this.getRunnableMigrations(data.currentVersion, data.targetVersion)
       )
-      .then(relevantMigrations => {
-        if (relevantMigrations.length > 0) {
-          return this.runMigrations(relevantMigrations)
-        }
-      })
+      .then(runnableMigrations => this.runMigrations(runnableMigrations))
   }
 
   /**

--- a/postgrator.js
+++ b/postgrator.js
@@ -201,11 +201,15 @@ class Postgrator {
         )
         .map(migration => {
           migration.schemaVersionSQL = `
-            INSERT INTO ${config.schemaTable} (version, name, md5) 
+            INSERT INTO ${config.schemaTable} (version, name, md5, run_at) 
             VALUES (
               ${migration.version}, 
               '${migration.name}', 
-              '${migration.md5}'
+              '${migration.md5}',
+              '${new Date()
+                .toISOString()
+                .replace('T', ' ')
+                .replace('Z', '')}'
             );`
           return migration
         })

--- a/postgrator.js
+++ b/postgrator.js
@@ -132,13 +132,12 @@ class Postgrator {
             migration =>
               migration.action === 'do' &&
               migration.version > 0 &&
-              migration.version <= currentVersion &&
-              config.driver === 'pg'
+              migration.version <= currentVersion
           )
           .map(migration => {
-            migration.md5Sql = `SELECT md5 FROM ${
-              config.schemaTable
-            } WHERE version = ${migration.version};`
+            migration.md5Sql = `
+              SELECT md5 FROM ${config.schemaTable} 
+              WHERE version = ${migration.version};`
             return migration
           })
 
@@ -201,16 +200,13 @@ class Postgrator {
             migration.version <= targetVersion
         )
         .map(migration => {
-          migration.schemaVersionSQL =
-            config.driver === 'pg'
-              ? `INSERT INTO ${
-                  config.schemaTable
-                } (version, name, md5) VALUES (${migration.version}, '${
-                  migration.name
-                }', '${migration.md5}');`
-              : `INSERT INTO ${config.schemaTable} (version) VALUES (${
-                  migration.version
-                });`
+          migration.schemaVersionSQL = `
+            INSERT INTO ${config.schemaTable} (version, name, md5) 
+            VALUES (
+              ${migration.version}, 
+              '${migration.name}', 
+              '${migration.md5}'
+            );`
           return migration
         })
         .sort(sortMigrationsAsc)
@@ -224,9 +220,9 @@ class Postgrator {
             migration.version > targetVersion
         )
         .map(migration => {
-          migration.schemaVersionSQL = `DELETE FROM ${
-            config.schemaTable
-          } WHERE version = ${migration.version};`
+          migration.schemaVersionSQL = `
+            DELETE FROM ${config.schemaTable} 
+            WHERE version = ${migration.version};`
           return migration
         })
         .sort(sortMigrationsDesc)

--- a/postgrator.js
+++ b/postgrator.js
@@ -190,7 +190,7 @@ class Postgrator {
           migration.action === 'do' &&
           migration.version > 0 &&
           migration.version <= currentVersion &&
-          (config.driver === 'pg' || config.driver === 'pg.js')
+          config.driver === 'pg'
         ) {
           migration.md5Sql = `SELECT md5 FROM ${
             config.schemaTable

--- a/postgrator.js
+++ b/postgrator.js
@@ -266,7 +266,8 @@ class Postgrator {
     return this.prep()
       .then(() => this.getMigrations())
       .then(() => {
-        if (target.toLowerCase() === 'max') {
+        const cleaned = target.toLowerCase().trim()
+        if (cleaned === 'max' || cleaned === '') {
           return this.getMaxVersion()
         } else {
           return Number(target)
@@ -274,7 +275,7 @@ class Postgrator {
       })
       .then(targetVersion => {
         if (targetVersion === undefined) {
-          throw new Error('No target version supplied')
+          throw new Error('targetVersion undefined')
         }
         data.targetVersion = targetVersion
         return this.getCurrentVersion()

--- a/postgrator.js
+++ b/postgrator.js
@@ -279,11 +279,11 @@ class Postgrator {
         if (config.driver === 'pg') {
           // config.schemaTable exists, does it have the md5 column? (PostgreSQL only)
           const sql = `
-          SELECT column_name, data_type, character_maximum_length 
-          FROM INFORMATION_SCHEMA.COLUMNS 
-          WHERE table_name = '${config.schemaTable}' 
-          AND column_name = 'md5';
-        `
+            SELECT column_name, data_type, character_maximum_length 
+            FROM INFORMATION_SCHEMA.COLUMNS 
+            WHERE table_name = '${config.schemaTable}' 
+            AND column_name = 'md5';
+          `
           return this.runQuery(sql).then(result => {
             if (!result.rows || result.rows.length === 0) {
               // md5 column doesn't exist, add it

--- a/postgrator.js
+++ b/postgrator.js
@@ -7,300 +7,299 @@ const {
   sortMigrationsDesc
 } = require('./lib/utils.js')
 
-module.exports = Postgrator
+class Postgrator {
+  constructor(config) {
+    config.schemaTable = config.schemaTable || 'schemaversion'
+    this.config = config
+    this.migrations = []
+    this.commonClient = commonClient(config)
+  }
 
-function Postgrator(config) {
-  config.schemaTable = config.schemaTable || 'schemaversion'
-  this.config = config
-  this.migrations = []
-  this.commonClient = commonClient(config)
-}
-
-/**
- * Reads all migrations from directory
- * Returns promise of array of objects in format:
- * {version: n, action: 'do', filename: '0001.up.sql'}
- *
- * @returns {Promise} array of migration objects
- */
-Postgrator.prototype.getMigrations = function getMigrations() {
-  const { migrationDirectory, newline } = this.config
-  this.migrations = []
-
-  return new Promise((resolve, reject) => {
-    fs.readdir(migrationDirectory, (err, files) => {
-      if (err) {
-        return reject(err)
-      }
-      resolve(files)
+  /**
+   * Reads all migrations from directory
+   * Returns promise of array of objects in format:
+   * {version: n, action: 'do', filename: '0001.up.sql'}
+   *
+   * @returns {Promise} array of migration objects
+   */
+  getMigrations() {
+    const { migrationDirectory, newline } = this.config
+    this.migrations = []
+    return new Promise((resolve, reject) => {
+      fs.readdir(migrationDirectory, (err, files) => {
+        if (err) {
+          return reject(err)
+        }
+        resolve(files)
+      })
+    }).then(migrationFiles => {
+      migrationFiles.forEach(file => {
+        const m = file.split('.')
+        const name = m.length >= 3 ? m.slice(2, m.length - 1).join('.') : file
+        const filename = migrationDirectory + '/' + file
+        if (m[m.length - 1] === 'sql') {
+          this.migrations.push({
+            version: Number(m[0]),
+            action: m[1],
+            filename: file,
+            name: name,
+            md5: fileChecksum(filename, newline),
+            getSql: () => fs.readFileSync(filename, 'utf8')
+          })
+        } else if (m[m.length - 1] === 'js') {
+          const jsModule = require(filename)
+          const sql = jsModule.generateSql()
+          this.migrations.push({
+            version: Number(m[0]),
+            action: m[1],
+            filename: file,
+            name: name,
+            md5: checksum(sql, newline),
+            getSql: () => sql
+          })
+        }
+      })
+      this.migrations = this.migrations.filter(
+        migration => !isNaN(migration.version)
+      )
+      return this.migrations
     })
-  }).then(migrationFiles => {
-    migrationFiles.forEach(file => {
-      const m = file.split('.')
-      const name = m.length >= 3 ? m.slice(2, m.length - 1).join('.') : file
-      const filename = migrationDirectory + '/' + file
-      if (m[m.length - 1] === 'sql') {
-        this.migrations.push({
-          version: Number(m[0]),
-          action: m[1],
-          filename: file,
-          name: name,
-          md5: fileChecksum(filename, newline),
-          getSql: () => fs.readFileSync(filename, 'utf8')
-        })
-      } else if (m[m.length - 1] === 'js') {
-        const jsModule = require(filename)
-        const sql = jsModule.generateSql()
-        this.migrations.push({
-          version: Number(m[0]),
-          action: m[1],
-          filename: file,
-          name: name,
-          md5: checksum(sql, newline),
-          getSql: () => sql
-        })
-      }
-    })
-    this.migrations = this.migrations.filter(
-      migration => !isNaN(migration.version)
-    )
-    return this.migrations
-  })
-}
+  }
 
-/**
- * Exposed for testing, but otherwise internal
- * Connects the database driver if it is not currently connected.
- * Executes an arbitrary sql query using the common client
- *
- * @returns {Promise} result of query
- * @param {String} query sql query to execute
- */
-Postgrator.prototype.runQuery = function runQuery(query) {
-  const { commonClient } = this
-
-  if (commonClient.connected) {
-    return commonClient.runQuery(query)
-  } else {
-    return commonClient.createConnection().then(() => {
-      commonClient.connected = true
+  /**
+   * Exposed for testing, but otherwise internal
+   * Connects the database driver if it is not currently connected.
+   * Executes an arbitrary sql query using the common client
+   *
+   * @returns {Promise} result of query
+   * @param {String} query sql query to execute
+   */
+  runQuery(query) {
+    const { commonClient } = this
+    if (commonClient.connected) {
       return commonClient.runQuery(query)
-    })
-  }
-}
-
-/**
- * Ends the commonClient's connection to database
- *
- * @returns {Promise}
- */
-Postgrator.prototype.endConnection = function endConnection() {
-  const { commonClient } = this
-  if (commonClient.connected) {
-    return commonClient.endConnection().then(() => {
-      commonClient.connected = false
-    })
-  }
-  return Promise.resolve()
-}
-
-/**
- * Gets the current version of the schema from the database.
- * Otherwise 0 if no version has been run
- *
- * @returns {Promise} current schema version
- */
-Postgrator.prototype.getCurrentVersion = function getCurrentVersion() {
-  const currentVersionSql = this.commonClient.queries.getCurrentVersion
-  return this.runQuery(currentVersionSql).then(result => {
-    if (result.rows.length > 0) {
-      return result.rows[0].version
     } else {
-      return 0
+      return commonClient.createConnection().then(() => {
+        commonClient.connected = true
+        return commonClient.runQuery(query)
+      })
     }
-  })
-}
-
-/**
- * Returns an object with current applied version of the schema from
- * the database and max version of migration available
- *
- * @returns {Promise}
- */
-Postgrator.prototype.getMaxVersion = function getMaxVersion() {
-  const { migrations } = this
-  return Promise.resolve()
-    .then(() => {
-      if (migrations.length) {
-        return migrations
-      } else {
-        return this.getMigrations()
-      }
-    })
-    .then(migrations => {
-      const versions = migrations.map(migration => migration.version)
-      return Math.max.apply(null, versions)
-    })
-}
-
-/**
- * Runs the migrations in the order to reach target version
- *
- * @returns {Promise} - Array of migration objects to appled to database
- * @param {Array} migrations - Array of migration objects to apply to database
- */
-Postgrator.prototype.runMigrations = function runMigrations(migrations = []) {
-  let seq = Promise.resolve()
-  const appliedMigrations = []
-  migrations.forEach(migration => {
-    seq = seq.then(() => {
-      const sql = migration.getSql()
-      if (migration.md5Sql) {
-        return this.runQuery(migration.md5Sql).then(result => {
-          const row = result.rows[0]
-          if (row && row.md5 && row.md5 !== migration.md5) {
-            const msg = `For migration [${
-              migration.version
-            }], expected MD5 checksum [${migration.md5}] but got [${row.md5}]`
-            throw new Error(msg)
-          }
-        })
-      } else {
-        return this.runQuery(sql)
-          .then(() => this.runQuery(migration.schemaVersionSQL))
-          .then(() => appliedMigrations.push(migration))
-      }
-    })
-  })
-  return seq.then(() => appliedMigrations)
-}
-
-/**
- * returns an array of relevant migrations based on the target and current version passed.
- * returned array is sorted in the order it needs to be run
- *
- * @returns {Array} Sorted array of relevant migration objects
- * @param {Number} currentVersion
- * @param {Number} targetVersion
- */
-Postgrator.prototype.getRelevantMigrations = function getRelevantMigrations(
-  currentVersion,
-  targetVersion
-) {
-  let relevantMigrations = []
-  const { config, migrations } = this
-  if (targetVersion >= currentVersion) {
-    // get all up migrations > currentVersion and <= targetVersion
-    migrations.forEach(migration => {
-      if (
-        migration.action === 'do' &&
-        migration.version > 0 &&
-        migration.version <= currentVersion &&
-        (config.driver === 'pg' || config.driver === 'pg.js')
-      ) {
-        migration.md5Sql = `SELECT md5 FROM ${
-          config.schemaTable
-        } WHERE version = ${migration.version};`
-        relevantMigrations.push(migration)
-      }
-      if (
-        migration.action === 'do' &&
-        migration.version > currentVersion &&
-        migration.version <= targetVersion
-      ) {
-        migration.schemaVersionSQL =
-          config.driver === 'pg'
-            ? `INSERT INTO ${config.schemaTable} (version, name, md5) VALUES (${
-                migration.version
-              }, '${migration.name}', '${migration.md5}');`
-            : `INSERT INTO ${config.schemaTable} (version) VALUES (${
-                migration.version
-              });`
-        relevantMigrations.push(migration)
-      }
-    })
-    relevantMigrations = relevantMigrations.sort(sortMigrationsAsc)
-  } else if (targetVersion < currentVersion) {
-    migrations.forEach(migration => {
-      if (
-        migration.action === 'undo' &&
-        migration.version <= currentVersion &&
-        migration.version > targetVersion
-      ) {
-        migration.schemaVersionSQL = `DELETE FROM ${
-          config.schemaTable
-        } WHERE version = ${migration.version};`
-        relevantMigrations.push(migration)
-      }
-    })
-    relevantMigrations = relevantMigrations.sort(sortMigrationsDesc)
   }
-  return relevantMigrations
-}
 
-/**
- * Main method to move a schema to a particular version.
- * A target must be specified, otherwise nothing is run.
- *
- * @returns {Promise}
- * @param {String} target - version to migrate as string or number (handled as  numbers internally)
- */
-Postgrator.prototype.migrate = function(target = '') {
-  return this.prep()
-    .then(() => this.getMigrations())
-    .then(() => {
-      if (target.toLowerCase() === 'max') {
-        return this.getMaxVersion()
+  /**
+   * Ends the commonClient's connection to database
+   *
+   * @returns {Promise}
+   */
+  endConnection() {
+    const { commonClient } = this
+    if (commonClient.connected) {
+      return commonClient.endConnection().then(() => {
+        commonClient.connected = false
+      })
+    }
+    return Promise.resolve()
+  }
+
+  /**
+   * Gets the current version of the schema from the database.
+   * Otherwise 0 if no version has been run
+   *
+   * @returns {Promise} current schema version
+   */
+  getCurrentVersion() {
+    const currentVersionSql = this.commonClient.queries.getCurrentVersion
+    return this.runQuery(currentVersionSql).then(result => {
+      if (result.rows.length > 0) {
+        return result.rows[0].version
       } else {
-        return Number(target)
+        return 0
       }
     })
-    .then(targetVersion => {
-      if (targetVersion === undefined) {
-        throw new Error('No target version supplied')
-      }
-      return this.getCurrentVersion()
-        .then(currentVersion => {
-          return this.getRelevantMigrations(currentVersion, targetVersion)
-        })
-        .then(relevantMigrations => {
-          if (relevantMigrations.length > 0) {
-            return this.runMigrations(relevantMigrations)
-          }
-        })
-    })
-}
+  }
 
-/**
- * Creates the table required for Postgrator to keep track of which migrations have been run.
- *
- * @returns {Promise}
- */
-Postgrator.prototype.prep = function prep() {
-  const { commonClient, config } = this
-  return this.runQuery(commonClient.queries.checkTable).then(result => {
-    if (result.rows && result.rows.length > 0) {
-      if (config.driver === 'pg') {
-        // config.schemaTable exists, does it have the md5 column? (PostgreSQL only)
-        const sql = `
+  /**
+   * Returns an object with current applied version of the schema from
+   * the database and max version of migration available
+   *
+   * @returns {Promise}
+   */
+  getMaxVersion() {
+    const { migrations } = this
+    return Promise.resolve()
+      .then(() => {
+        if (migrations.length) {
+          return migrations
+        } else {
+          return this.getMigrations()
+        }
+      })
+      .then(migrations => {
+        const versions = migrations.map(migration => migration.version)
+        return Math.max.apply(null, versions)
+      })
+  }
+
+  /**
+   * Runs the migrations in the order to reach target version
+   *
+   * @returns {Promise} - Array of migration objects to appled to database
+   * @param {Array} migrations - Array of migration objects to apply to database
+   */
+  runMigrations(migrations = []) {
+    let seq = Promise.resolve()
+    const appliedMigrations = []
+    migrations.forEach(migration => {
+      seq = seq.then(() => {
+        const sql = migration.getSql()
+        if (migration.md5Sql) {
+          return this.runQuery(migration.md5Sql).then(result => {
+            const row = result.rows[0]
+            if (row && row.md5 && row.md5 !== migration.md5) {
+              const msg = `For migration [${
+                migration.version
+              }], expected MD5 checksum [${migration.md5}] but got [${row.md5}]`
+              throw new Error(msg)
+            }
+          })
+        } else {
+          return this.runQuery(sql)
+            .then(() => this.runQuery(migration.schemaVersionSQL))
+            .then(() => appliedMigrations.push(migration))
+        }
+      })
+    })
+    return seq.then(() => appliedMigrations)
+  }
+
+  /**
+   * returns an array of relevant migrations based on the target and current version passed.
+   * returned array is sorted in the order it needs to be run
+   *
+   * @returns {Array} Sorted array of relevant migration objects
+   * @param {Number} currentVersion
+   * @param {Number} targetVersion
+   */
+  getRelevantMigrations(currentVersion, targetVersion) {
+    let relevantMigrations = []
+    const { config, migrations } = this
+    if (targetVersion >= currentVersion) {
+      // get all up migrations > currentVersion and <= targetVersion
+      migrations.forEach(migration => {
+        if (
+          migration.action === 'do' &&
+          migration.version > 0 &&
+          migration.version <= currentVersion &&
+          (config.driver === 'pg' || config.driver === 'pg.js')
+        ) {
+          migration.md5Sql = `SELECT md5 FROM ${
+            config.schemaTable
+          } WHERE version = ${migration.version};`
+          relevantMigrations.push(migration)
+        }
+        if (
+          migration.action === 'do' &&
+          migration.version > currentVersion &&
+          migration.version <= targetVersion
+        ) {
+          migration.schemaVersionSQL =
+            config.driver === 'pg'
+              ? `INSERT INTO ${
+                  config.schemaTable
+                } (version, name, md5) VALUES (${migration.version}, '${
+                  migration.name
+                }', '${migration.md5}');`
+              : `INSERT INTO ${config.schemaTable} (version) VALUES (${
+                  migration.version
+                });`
+          relevantMigrations.push(migration)
+        }
+      })
+      relevantMigrations = relevantMigrations.sort(sortMigrationsAsc)
+    } else if (targetVersion < currentVersion) {
+      migrations.forEach(migration => {
+        if (
+          migration.action === 'undo' &&
+          migration.version <= currentVersion &&
+          migration.version > targetVersion
+        ) {
+          migration.schemaVersionSQL = `DELETE FROM ${
+            config.schemaTable
+          } WHERE version = ${migration.version};`
+          relevantMigrations.push(migration)
+        }
+      })
+      relevantMigrations = relevantMigrations.sort(sortMigrationsDesc)
+    }
+    return relevantMigrations
+  }
+
+  /**
+   * Main method to move a schema to a particular version.
+   * A target must be specified, otherwise nothing is run.
+   *
+   * @returns {Promise}
+   * @param {String} target - version to migrate as string or number (handled as  numbers internally)
+   */
+  migrate(target = '') {
+    return this.prep()
+      .then(() => this.getMigrations())
+      .then(() => {
+        if (target.toLowerCase() === 'max') {
+          return this.getMaxVersion()
+        } else {
+          return Number(target)
+        }
+      })
+      .then(targetVersion => {
+        if (targetVersion === undefined) {
+          throw new Error('No target version supplied')
+        }
+        return this.getCurrentVersion()
+          .then(currentVersion => {
+            return this.getRelevantMigrations(currentVersion, targetVersion)
+          })
+          .then(relevantMigrations => {
+            if (relevantMigrations.length > 0) {
+              return this.runMigrations(relevantMigrations)
+            }
+          })
+      })
+  }
+
+  /**
+   * Creates the table required for Postgrator to keep track of which migrations have been run.
+   *
+   * @returns {Promise}
+   */
+  prep() {
+    const { commonClient, config } = this
+    return this.runQuery(commonClient.queries.checkTable).then(result => {
+      if (result.rows && result.rows.length > 0) {
+        if (config.driver === 'pg') {
+          // config.schemaTable exists, does it have the md5 column? (PostgreSQL only)
+          const sql = `
           SELECT column_name, data_type, character_maximum_length 
           FROM INFORMATION_SCHEMA.COLUMNS 
           WHERE table_name = '${config.schemaTable}' 
           AND column_name = 'md5';
         `
-        return this.runQuery(sql).then(result => {
-          if (!result.rows || result.rows.length === 0) {
-            // md5 column doesn't exist, add it
-            const sql = `
+          return this.runQuery(sql).then(result => {
+            if (!result.rows || result.rows.length === 0) {
+              // md5 column doesn't exist, add it
+              const sql = `
               ALTER TABLE ${config.schemaTable} 
               ADD COLUMN md5 text DEFAULT '';
             `
-            return this.runQuery(sql)
-          }
-        })
+              return this.runQuery(sql)
+            }
+          })
+        }
+      } else {
+        return this.runQuery(commonClient.queries.makeTable)
       }
-    } else {
-      return this.runQuery(commonClient.queries.makeTable)
-    }
-  })
+    })
+  }
 }
+
+module.exports = Postgrator

--- a/postgrator.js
+++ b/postgrator.js
@@ -288,9 +288,9 @@ class Postgrator {
             if (!result.rows || result.rows.length === 0) {
               // md5 column doesn't exist, add it
               const sql = `
-              ALTER TABLE ${config.schemaTable} 
-              ADD COLUMN md5 text DEFAULT '';
-            `
+                ALTER TABLE ${config.schemaTable} 
+                ADD COLUMN md5 text DEFAULT '';
+              `
               return this.runQuery(sql)
             }
           })

--- a/postgrator.js
+++ b/postgrator.js
@@ -67,7 +67,6 @@ class Postgrator {
   }
 
   /**
-   * Exposed for testing, but otherwise internal
    * Connects the database driver if it is not currently connected.
    * Executes an arbitrary sql query using the common client
    *

--- a/postgrator.js
+++ b/postgrator.js
@@ -74,7 +74,7 @@ Postgrator.prototype.getMigrations = function getMigrations() {
  * Executes an arbitrary sql query using the common client
  *
  * @returns {Promise} result of query
- * @param {*} query sql query to execute
+ * @param {String} query sql query to execute
  */
 Postgrator.prototype.runQuery = function runQuery(query) {
   const { commonClient } = this
@@ -180,8 +180,8 @@ Postgrator.prototype.runMigrations = function runMigrations(migrations = []) {
  * returned array is sorted in the order it needs to be run
  *
  * @returns {Array} Sorted array of relevant migration objects
- * @param {*} currentVersion
- * @param {*} targetVersion
+ * @param {Number} currentVersion
+ * @param {Number} targetVersion
  */
 Postgrator.prototype.getRelevantMigrations = function getRelevantMigrations(
   currentVersion,
@@ -243,7 +243,7 @@ Postgrator.prototype.getRelevantMigrations = function getRelevantMigrations(
  * A target must be specified, otherwise nothing is run.
  *
  * @returns {Promise}
- * @param {*} target - version to migrate as string or number (handled as  numbers internally)
+ * @param {String} target - version to migrate as string or number (handled as  numbers internally)
  */
 Postgrator.prototype.migrate = function(target = '') {
   return this.prep()

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ const postgrator = new Postgrator({
 ```
 
 
-### Postgres specific notes:
+### Postgres options:
 
 Postgres supports connection string url as well as simple ssl config:
 
@@ -140,7 +140,7 @@ const postgrator = new Postgrator({
 ```
 
 
-### SQL Server specific notes:
+### SQL Server options:
 
 For SQL Server, you may optionally provide an additional options configuration. 
 This may be necessary if requiring a secure connection for Azure.

--- a/readme.md
+++ b/readme.md
@@ -19,23 +19,27 @@ npm install mssql
 ```
 
 
-## Version 3.0 Breaking changes (unreleased, in development)
+## Version 3.0 Features & breaking changes (unreleased, in development)
 
-- [x] Node 6 or greater now required
-- [x] DB drivers must be installed prior to use (`pg`, `mysql`, `mssql`)
-- [x] `pg.js` and `tedious` no longer valid driver config option
-- [x] Callback API replaced with promise-based functions
-- [x] `.getVersions()` removed in favor of `.getMaxVersion()`, `.getCurrentVersion()`, and `.getMigrations()`
-- [x] Logging to console removed (and so has config.logProgress)
-- [x] Calling `.migrate()` without input migrates to latest/max
+### Features & Improvements
+- `run_at` timestamp column added to schema table
+- `md5` and `name` columns added for all implementations
+- Checksum validation now implemented for all drivers
+- Checksum validation may be skipped using config `validateChecksums: false`
+- Callback API replaced with Promises
+- Connections opened/closed automatically (no more `.endConnection()`)
+- Lots of tests
+
+### Breaking changes
+- Node 6 or greater now required
+- DB drivers must be installed prior to use (`pg`, `mysql`, `mssql`)
+- Calling `.migrate()` without input migrates to latest/max
+- `pg.js` and `tedious` no longer valid driver config option
+- None of the API is the same
+- Logging to console removed (and so has config.logProgress)
 
 ### TODO 
-- [x] Use ES6 class
-- [x] Auto close connection at end of migration
-- [x] Add checksums for mysql, mssql
-- [x] Make checksum optional
-- [x] Add timestamp to migration table
-- [x] change `.getCurrentVersion()` to `.getDatabaseVersion()`
+- [ ] document utility functions
 
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,20 @@ npm install mssql
 
 ## Version 3.0 Breaking changes (unreleased, in development)
 
-- DB drivers must be installed prior to use (`pg`, `mysql`, `mssql`)
-- `pg.js` and `tedious` are no longer valid driver config option
-- All callback functions have been replaced with promise-based functions
-- `.getVersions()` has been removed in favor of `.getMaxVersion()`, `.getCurrentVersion()`, and `.getMigrations()`
-- Node 6 or greater is now required
-- logging to console has been removed (and so has config.logProgress)
+[x] Node 6 or greater now required
+[x] DB drivers must be installed prior to use (`pg`, `mysql`, `mssql`)
+[x] `pg.js` and `tedious` no longer valid driver config option
+[x] Callback API replaced with promise-based functions
+[x] `.getVersions()` removed in favor of `.getMaxVersion()`, `.getCurrentVersion()`, and `.getMigrations()`
+[x] Logging to console removed (and so has config.logProgress)
+
+### TODO 
+[ ] Add checksums for mysql, mssql
+[ ] Use ES6 class
+[ ] Auto close connection at end of migration
+[ ] Checksum for multiple line endings (remove newline dep)
+[ ] Make checksum optional
+[ ] Add timestamp to migration table
 
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Postgrator 3.x.x
+# Postgrator 3
 
 A Node.js SQL migration library using a directory of plain SQL scripts.
 Supports Postgres, MySQL, and SQL Server.
@@ -21,20 +21,20 @@ npm install mssql
 
 ## Version 3.0 Breaking changes (unreleased, in development)
 
-[x] Node 6 or greater now required
-[x] DB drivers must be installed prior to use (`pg`, `mysql`, `mssql`)
-[x] `pg.js` and `tedious` no longer valid driver config option
-[x] Callback API replaced with promise-based functions
-[x] `.getVersions()` removed in favor of `.getMaxVersion()`, `.getCurrentVersion()`, and `.getMigrations()`
-[x] Logging to console removed (and so has config.logProgress)
+- [x] Node 6 or greater now required
+- [x] DB drivers must be installed prior to use (`pg`, `mysql`, `mssql`)
+- [x] `pg.js` and `tedious` no longer valid driver config option
+- [x] Callback API replaced with promise-based functions
+- [x] `.getVersions()` removed in favor of `.getMaxVersion()`, `.getCurrentVersion()`, and `.getMigrations()`
+- [x] Logging to console removed (and so has config.logProgress)
 
 ### TODO 
-[ ] Add checksums for mysql, mssql
-[ ] Use ES6 class
-[ ] Auto close connection at end of migration
-[ ] Checksum for multiple line endings (remove newline dep)
-[ ] Make checksum optional
-[ ] Add timestamp to migration table
+- [ ] Add checksums for mysql, mssql
+- [ ] Use ES6 class
+- [ ] Auto close connection at end of migration
+- [ ] Checksum for multiple line endings (remove newline dep)
+- [ ] Make checksum optional
+- [ ] Add timestamp to migration table
 
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -27,10 +27,10 @@ npm install mssql
 - [x] Callback API replaced with promise-based functions
 - [x] `.getVersions()` removed in favor of `.getMaxVersion()`, `.getCurrentVersion()`, and `.getMigrations()`
 - [x] Logging to console removed (and so has config.logProgress)
+- [x] Use ES6 class
 
 ### TODO 
 - [ ] Add checksums for mysql, mssql
-- [ ] Use ES6 class
 - [ ] Auto close connection at end of migration
 - [ ] Checksum for multiple line endings (remove newline dep)
 - [ ] Make checksum optional

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,38 @@ const postgrator = new Postgrator({
 Reference options for mssql for more details: [https://www.npmjs.com/package/mssql](https://www.npmjs.com/package/mssql)
 
 
+### Utility methods
+
+Some of postgrator's methods may come in useful performing other migration tasks
+
+```js
+// To get max version available from filesystem
+// version returned as number, not string
+postgrator.getMaxVersion()
+  .then(version => console.log(version))
+  .catch(error => console.error(error))
+
+// "current" database schema version
+// version returned as number, not string
+postgrator.getDatabaseVersion()
+  .then(version => console.log(version))
+  .catch(error => console.error(error))
+
+// To get all migrations from directory and parse metadata
+postgrator.getMigrations()
+  .then(migrations => console.log(migrations))
+  .catch(error => console.error(error))
+
+// Run arbitrary SQL query against database
+// Connection is established, query is run, then connection is ended
+// `results.rows` will be an array of row objects, with column names as keys
+// `results` object may have other properties depending on db driver
+postgrator.runQuery('SELECT * FROM sometable')
+  .then(results => console.log(results))
+  .catch(error => console.error(error))
+```
+
+
 ## What Postgrator is doing
 
 When first run against your database, *Postgrator will create the table specified by config.schemaTable.* Postgrator relies on this table to track what version the database is at.

--- a/readme.md
+++ b/readme.md
@@ -32,10 +32,10 @@ npm install mssql
 ### TODO 
 - [x] Use ES6 class
 - [x] Auto close connection at end of migration
-- [ ] Add checksums for mysql, mssql
-- [ ] Checksum for multiple line endings (remove newline dep)
+- [x] Add checksums for mysql, mssql
 - [ ] Make checksum optional
-- [ ] Add timestamp to migration table
+- [x] Add timestamp to migration table
+- [ ] change `.getCurrentVersion()` to `.getDatabaseVersion()`
 
 
 ## Usage
@@ -155,14 +155,14 @@ If a migration fails, Postgrator will stop running any further migrations. It is
 Line feeds: Unix/Mac uses LF, Windows uses 'CRLF', this causes problems for postgrator when calculating the md5 checksum of the migration files - particularly if some developers are on windows, some are on mac, etc. To negate this, you can use the `newline` config flag to tell postgrator to always use a particular line feed, e.g.
 
 ```js
-postgrator.setConfig({
+const postgrator = new Postgrator({
   migrationDirectory: __dirname + '/migrations',
   driver: 'pg', // or pg.js, mysql, mssql, tedious
   host: '127.0.0.1',
   database: 'databasename',
   username: 'username',
   password: 'password',
-  newline: 'CRLF'
+  newline: 'CRLF' // force using 'CRLF' or 'LF'
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ npm install mssql
 
 ### TODO 
 - [x] Use ES6 class
+- [x] Auto close connection at end of migration
 - [ ] Add checksums for mysql, mssql
-- [ ] Auto close connection at end of migration
 - [ ] Checksum for multiple line endings (remove newline dep)
 - [ ] Make checksum optional
 - [ ] Add timestamp to migration table

--- a/readme.md
+++ b/readme.md
@@ -27,9 +27,10 @@ npm install mssql
 - [x] Callback API replaced with promise-based functions
 - [x] `.getVersions()` removed in favor of `.getMaxVersion()`, `.getCurrentVersion()`, and `.getMigrations()`
 - [x] Logging to console removed (and so has config.logProgress)
-- [x] Use ES6 class
+- [x] Calling `.migrate()` without input migrates to latest/max
 
 ### TODO 
+- [x] Use ES6 class
 - [ ] Add checksums for mysql, mssql
 - [ ] Auto close connection at end of migration
 - [ ] Checksum for multiple line endings (remove newline dep)

--- a/test/api.js
+++ b/test/api.js
@@ -16,14 +16,12 @@ describe('API', function() {
   it('Migrates up to 003', function() {
     return postgrator.migrate('003').then(migrations => {
       assert.equal(migrations.length, 3, '3 migrations run')
-      return postgrator.endConnection()
     })
   })
 
   it('Implements getCurrentVersion', function() {
     return postgrator.getCurrentVersion().then(currentVersion => {
       assert.equal(currentVersion, 3)
-      return postgrator.endConnection()
     })
   })
 
@@ -35,21 +33,18 @@ describe('API', function() {
       assert.equal(m.action, 'do')
       assert.equal(m.filename, '001.do.sql')
       assert(m.hasOwnProperty('name'))
-      return postgrator.endConnection()
     })
   })
 
   it('Implements getMaxVersion', function() {
     return postgrator.getMaxVersion().then(max => {
       assert.equal(max, 6)
-      return postgrator.endConnection()
     })
   })
 
   it('Migrates down to 000', function() {
     return postgrator.migrate('000').then(migrations => {
       assert.equal(migrations.length, 3, '3 migrations run')
-      return postgrator.endConnection()
     })
   })
 

--- a/test/api.js
+++ b/test/api.js
@@ -1,60 +1,61 @@
 /* global it, describe */
 const assert = require('assert')
-const postgrator = require('../postgrator')
+const Postgrator = require('../postgrator')
 
 const path = require('path')
 const migrationDirectory = path.join(__dirname, 'migrations')
 const pgUrl = 'tcp://postgrator:postgrator@localhost:5432/postgrator'
 
 describe('API', function() {
-  postgrator.setConfig({
+  const postgrator = new Postgrator({
     driver: 'pg',
     migrationDirectory: migrationDirectory,
     connectionString: pgUrl
   })
 
-  it('Migrates up to 003', function(done) {
-    postgrator.migrate('003', function(err, migrations) {
-      assert.ifError(err)
+  it('Migrates up to 003', function() {
+    return postgrator.migrate('003').then(migrations => {
       assert.equal(migrations.length, 3, '3 migrations run')
-      postgrator.endConnection(done)
+      return postgrator.endConnection()
     })
   })
 
-  it('Implements getCurrentVersion', function(done) {
-    postgrator.getCurrentVersion(function(err, currentVersion) {
-      assert.ifError(err)
+  it('Implements getCurrentVersion', function() {
+    return postgrator.getCurrentVersion().then(currentVersion => {
       assert.equal(currentVersion, 3)
-      postgrator.endConnection(done)
+      return postgrator.endConnection()
     })
   })
 
-  // TODO replace this with getMigrations(), getMax()
-  it('Implements getVersions', function(done) {
-    postgrator.getVersions(function(err, versions) {
-      assert.ifError(err)
-      assert(versions)
-      assert.equal(versions.current, 3)
-      assert.equal(versions.max, 6)
-      // NOTE versions.migrations is array of version numbers
-      // (do and undo, so they are duplicated)
-      assert(Array.isArray(versions.migrations))
-      postgrator.endConnection(done)
+  it('Implements getMigrations', function() {
+    return postgrator.getMigrations().then(migrations => {
+      assert.equal(migrations.length, 11)
+      const m = migrations[0]
+      assert.equal(m.version, 1)
+      assert.equal(m.action, 'do')
+      assert.equal(m.filename, '001.do.sql')
+      assert(m.hasOwnProperty('name'))
+      return postgrator.endConnection()
     })
   })
 
-  it('Migrates down to 000', function(done) {
-    postgrator.migrate('000', function(err, migrations) {
-      assert.ifError(err)
+  it('Implements getMaxVersion', function() {
+    return postgrator.getMaxVersion().then(max => {
+      assert.equal(max, 6)
+      return postgrator.endConnection()
+    })
+  })
+
+  it('Migrates down to 000', function() {
+    return postgrator.migrate('000').then(migrations => {
       assert.equal(migrations.length, 3, '3 migrations run')
-      postgrator.endConnection(done)
+      return postgrator.endConnection()
     })
   })
 
-  it('Drops the schemaversion table', function(done) {
-    postgrator.runQuery('DROP TABLE schemaversion', function(err) {
-      assert.ifError(err)
-      postgrator.endConnection(done)
-    })
+  it('Drops the schemaversion table', function() {
+    return postgrator
+      .runQuery('DROP TABLE schemaversion')
+      .then(() => postgrator.endConnection())
   })
 })

--- a/test/api.js
+++ b/test/api.js
@@ -49,8 +49,6 @@ describe('API', function() {
   })
 
   after(function() {
-    return postgrator
-      .runQuery('DROP TABLE schemaversion')
-      .then(() => postgrator.endConnection())
+    return postgrator.runQuery('DROP TABLE schemaversion')
   })
 })

--- a/test/api.js
+++ b/test/api.js
@@ -29,7 +29,7 @@ describe('API', function() {
 
   it('Implements getMigrations', function() {
     return postgrator.getMigrations().then(migrations => {
-      assert.equal(migrations.length, 11)
+      assert.equal(migrations.length, 12)
       const m = migrations[0]
       assert.equal(m.version, 1)
       assert.equal(m.action, 'do')

--- a/test/api.js
+++ b/test/api.js
@@ -19,9 +19,9 @@ describe('API', function() {
     })
   })
 
-  it('Implements getCurrentVersion', function() {
-    return postgrator.getCurrentVersion().then(currentVersion => {
-      assert.equal(currentVersion, 3)
+  it('Implements getDatabaseVersion', function() {
+    return postgrator.getDatabaseVersion().then(version => {
+      assert.equal(version, 3)
     })
   })
 

--- a/test/api.js
+++ b/test/api.js
@@ -13,15 +13,36 @@ describe('API', function() {
     connectionString: pgUrl
   })
 
+  const vStarted = []
+  const vFinished = []
+  const mStarted = []
+  const mFinished = []
+  postgrator.on('validation-started', migration => vStarted.push(migration))
+  postgrator.on('validation-finished', migration => vFinished.push(migration))
+  postgrator.on('migration-started', migration => mStarted.push(migration))
+  postgrator.on('migration-finished', migration => mFinished.push(migration))
+
   it('Migrates up to 003', function() {
     return postgrator.migrate('003').then(migrations => {
       assert.equal(migrations.length, 3, '3 migrations run')
     })
   })
 
+  it('Emits migration events', function() {
+    assert.equal(mStarted.length, 3)
+    assert.equal(mFinished.length, 3)
+  })
+
+  it('Emits validation events', function() {
+    return postgrator.migrate('004').then(migrations => {
+      assert.equal(vStarted.length, 3)
+      assert.equal(vFinished.length, 3)
+    })
+  })
+
   it('Implements getDatabaseVersion', function() {
     return postgrator.getDatabaseVersion().then(version => {
-      assert.equal(version, 3)
+      assert.equal(version, 4)
     })
   })
 
@@ -44,7 +65,7 @@ describe('API', function() {
 
   it('Migrates down to 000', function() {
     return postgrator.migrate('000').then(migrations => {
-      assert.equal(migrations.length, 3, '3 migrations run')
+      assert.equal(migrations.length, 4, '4 migrations run')
     })
   })
 

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -146,6 +146,25 @@ function testConfig(config) {
       return postgrator.migrate('00')
     })
 
+    it('Skips checksum validation if turned off', function() {
+      postgrator.config.validateChecksums = false
+      return postgrator
+        .migrate('003')
+        .then(migrations =>
+          postgrator.runQuery(
+            `UPDATE schemaversion SET md5 = 'baddata' WHERE version = 2`
+          )
+        )
+        .then(() => postgrator.migrate('006'))
+        .catch(error => assert.ifError(error))
+        .then(() => postgrator.getDatabaseVersion())
+        .then(version => assert.equal(version, 6))
+    })
+
+    it('Migrates down to 000 again', function() {
+      return postgrator.migrate('00')
+    })
+
     after(function() {
       return postgrator.runQuery('DROP TABLE schemaversion')
     })

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -40,7 +40,6 @@ function testConfig(config) {
     it('Handles current version', function() {
       return postgrator.migrate('002').then(migrations => {
         assert.equal(migrations.length, 0)
-        return postgrator.endConnection()
       })
     })
 
@@ -87,7 +86,7 @@ function testConfig(config) {
     })
 
     it('Migrates down to 000', function() {
-      return postgrator.migrate('00').then(() => postgrator.endConnection())
+      return postgrator.migrate('00')
     })
 
     it('Migrates to latest without input', function() {
@@ -100,13 +99,11 @@ function testConfig(config) {
     })
 
     it('Migrates down to 000 again', function() {
-      return postgrator.migrate('00').then(() => postgrator.endConnection())
+      return postgrator.migrate('00')
     })
 
     after(function() {
-      return postgrator
-        .runQuery('DROP TABLE schemaversion')
-        .then(() => postgrator.endConnection())
+      return postgrator.runQuery('DROP TABLE schemaversion')
     })
   })
 }

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -95,6 +95,20 @@ function testConfig(config) {
       return postgrator.migrate('00').then(() => postgrator.endConnection())
     })
 
+    it('Migrates to latest without input', function() {
+      return postgrator
+        .migrate()
+        .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
+        .then(result => {
+          assert.equal(result.rows.length, 6)
+          return postgrator.endConnection()
+        })
+    })
+
+    it('Migrates down to 000 again', function() {
+      return postgrator.migrate('00').then(() => postgrator.endConnection())
+    })
+
     after(function() {
       return postgrator
         .runQuery('DROP TABLE schemaversion')

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -137,9 +137,9 @@ function testConfig(config) {
         .then(() => postgrator.migrate('006'))
         .catch(error => {
           assert(error)
-          return postgrator.getCurrentVersion()
+          return postgrator.getDatabaseVersion()
         })
-        .then(currentVersion => assert.equal(currentVersion, 3))
+        .then(version => assert.equal(version, 3))
     })
 
     it('Migrates down to 000 again', function() {

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -24,6 +24,16 @@ testConfig({
   password: 'postgrator'
 })
 
+// SQL Server needs 3.25 GB of RAM and for some reason doesn't download...
+// testConfig({
+//   migrationDirectory: migrationDirectory,
+//   driver: 'mssql',
+//   host: 'localhost',
+//   database: 'master',
+//   username: 'sa',
+//   password: 'Postgrator123!'
+// })
+
 function testConfig(config) {
   describe(`Driver: ${config.driver}`, function() {
     const postgrator = new Postgrator(config)

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -25,14 +25,14 @@ testConfig({
 })
 
 // SQL Server needs 3.25 GB of RAM and for some reason doesn't download...
-// testConfig({
-//   migrationDirectory: migrationDirectory,
-//   driver: 'mssql',
-//   host: 'localhost',
-//   database: 'master',
-//   username: 'sa',
-//   password: 'Postgrator123!'
-// })
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'mssql',
+  host: 'localhost',
+  database: 'master',
+  username: 'sa',
+  password: 'Postgrator123!'
+})
 
 function testConfig(config) {
   describe(`Driver: ${config.driver}`, function() {

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -1,10 +1,9 @@
-/* global it, describe */
+/* global after, it, describe */
 const assert = require('assert')
 const Postgrator = require('../postgrator')
 
 const path = require('path')
 const migrationDirectory = path.join(__dirname, 'migrations')
-const pgUrl = 'tcp://postgrator:postgrator@localhost:5432/postgrator'
 
 testConfig({
   migrationDirectory: migrationDirectory,
@@ -26,7 +25,7 @@ testConfig({
 })
 
 function testConfig(config) {
-  describe(`Config API ${config.driver}`, function() {
+  describe(`Driver: ${config.driver}`, function() {
     const postgrator = new Postgrator(config)
 
     it('Migrates multiple versions up (000 -> 002)', function() {
@@ -96,32 +95,10 @@ function testConfig(config) {
       return postgrator.migrate('00').then(() => postgrator.endConnection())
     })
 
-    it('Drops the schemaversion table', function() {
+    after(function() {
       return postgrator
         .runQuery('DROP TABLE schemaversion')
         .then(() => postgrator.endConnection())
     })
   })
 }
-
-describe('Postgres connection string API', function() {
-  const postgrator = new Postgrator({
-    driver: 'pg',
-    migrationDirectory: migrationDirectory,
-    connectionString: pgUrl
-  })
-
-  it('Migrates up to 003', function() {
-    return postgrator.migrate('003').then(migrations => {
-      assert.equal(migrations.length, 3, '3 migrations run')
-      return postgrator.endConnection()
-    })
-  })
-
-  it('Migrates down to 000', function() {
-    return postgrator.migrate('000').then(migrations => {
-      assert.equal(migrations.length, 3, '3 migrations run')
-      return postgrator.endConnection()
-    })
-  })
-})

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -116,6 +116,26 @@ function testConfig(config) {
       return postgrator.migrate('00')
     })
 
+    it('Errors on invalid md5 check', function() {
+      return postgrator
+        .migrate('003')
+        .then(migrations =>
+          postgrator.runQuery(
+            `UPDATE schemaversion SET md5 = 'baddata' WHERE version = 2`
+          )
+        )
+        .then(() => postgrator.migrate('006'))
+        .catch(error => {
+          assert(error)
+          return postgrator.getCurrentVersion()
+        })
+        .then(currentVersion => assert.equal(currentVersion, 3))
+    })
+
+    it('Migrates down to 000 again', function() {
+      return postgrator.migrate('00')
+    })
+
     after(function() {
       return postgrator.runQuery('DROP TABLE schemaversion')
     })

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -24,15 +24,15 @@ testConfig({
   password: 'postgrator'
 })
 
-// SQL Server needs 3.25 GB of RAM and for some reason doesn't download...
-testConfig({
-  migrationDirectory: migrationDirectory,
-  driver: 'mssql',
-  host: 'localhost',
-  database: 'master',
-  username: 'sa',
-  password: 'Postgrator123!'
-})
+// SQL Server needs 3.25 GB of RAM
+// testConfig({
+//   migrationDirectory: migrationDirectory,
+//   driver: 'mssql',
+//   host: 'localhost',
+//   database: 'master',
+//   username: 'sa',
+//   password: 'Postgrator123!'
+// })
 
 function testConfig(config) {
   describe(`Driver: ${config.driver}`, function() {

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -34,7 +34,6 @@ function testConfig(config) {
         .then(migrations => postgrator.runQuery('SELECT name FROM person'))
         .then(results => {
           assert.equal(results.rows.length, 1)
-          return postgrator.endConnection()
         })
     })
 
@@ -51,7 +50,6 @@ function testConfig(config) {
         .then(migrations => postgrator.runQuery('SELECT name FROM person'))
         .then(results => {
           assert.equal(results.rows.length, 3)
-          return postgrator.endConnection()
         })
     })
 
@@ -64,7 +62,6 @@ function testConfig(config) {
         .then(result => {
           assert.equal(result.rows.length, 5)
           assert.equal(result.rows[4].name, process.env.TEST_NAME)
-          return postgrator.endConnection()
         })
     })
 
@@ -77,7 +74,6 @@ function testConfig(config) {
           assert.equal(result.rows.length, 6)
           assert.equal(result.rows[4].name, process.env.TEST_NAME)
           assert.equal(result.rows[5].name, process.env.TEST_ANOTHER_NAME)
-          return postgrator.endConnection()
         })
     })
 
@@ -87,7 +83,6 @@ function testConfig(config) {
         .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
         .then(result => {
           assert.equal(result.rows.length, 6)
-          return postgrator.endConnection()
         })
     })
 
@@ -101,7 +96,6 @@ function testConfig(config) {
         .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
         .then(result => {
           assert.equal(result.rows.length, 6)
-          return postgrator.endConnection()
         })
     })
 

--- a/test/driverIntegration.js
+++ b/test/driverIntegration.js
@@ -43,6 +43,20 @@ function testConfig(config) {
       })
     })
 
+    it('Has migration details in schema table', function() {
+      return postgrator
+        .runQuery(
+          `SELECT version, name, md5, run_at 
+          FROM schemaversion 
+          WHERE version = 2`
+        )
+        .then(results => {
+          assert.equal(results.rows[0].name, 'some-description')
+          assert(results.rows[0].run_at)
+          assert(results.rows[0].md5)
+        })
+    })
+
     it('Migrates one version up (002 -> 003', function() {
       return postgrator
         .migrate('003')

--- a/test/failMigrations/001.do.sql
+++ b/test/failMigrations/001.do.sql
@@ -1,0 +1,3 @@
+CREATE TABLE widgets (
+	name 	VARCHAR(50)
+);

--- a/test/failMigrations/001.undo.sql
+++ b/test/failMigrations/001.undo.sql
@@ -1,0 +1,1 @@
+DROP TABLE widgets;

--- a/test/failMigrations/002.do.fail-test.sql
+++ b/test/failMigrations/002.do.fail-test.sql
@@ -1,3 +1,6 @@
+-- NOTE without BEGIN/END you could end up with partial implemented migration, which is bad
+-- Postgres and SQL Server implicitly wrap 1 multi-statement execution in a transaction by default
+-- MySQL however does not, and you are left with partial migration implemented
 BEGIN
     INSERT INTO widgets (name) VALUES ('widget one');
     INSERT INTO widgets (name) VALUES ('widget two');

--- a/test/failMigrations/002.do.fail-test.sql
+++ b/test/failMigrations/002.do.fail-test.sql
@@ -1,0 +1,6 @@
+BEGIN
+    INSERT INTO widgets (name) VALUES ('widget one');
+    INSERT INTO widgets (name) VALUES ('widget two');
+    This isn't sql and its gonna break
+    INSERT INTO widgets (name) VALUES ('widget three');
+END

--- a/test/failMigrations/002.undo.fail-test.sql
+++ b/test/failMigrations/002.undo.fail-test.sql
@@ -1,0 +1,2 @@
+-- remove the record
+DELETE FROM person WHERE name = 'fred' AND age = 30;

--- a/test/migrationFailure.js
+++ b/test/migrationFailure.js
@@ -38,23 +38,14 @@ function testConfig(config) {
   describe(`Driver: ${config.driver}`, function() {
     const postgrator = new Postgrator(config)
 
-    let migrations = []
-    let error
-
     it('Handles failed migrations', function() {
-      return postgrator
-        .migrate()
-        .then(m => {
-          // postgrator.runQuery('SELECT name FROM person')
-          migrations = m
-        })
-        .catch(e => {
-          error = e
-        })
-        .then(() => {
-          assert.equal(migrations.length, 1, 'One migration expected')
-          assert(error, 'an error is expected from bad migration')
-        })
+      return postgrator.migrate().catch(error => {
+        assert(error, 'Error expected from bad migration')
+        assert(
+          error.appliedMigrations,
+          'appliedMigrations decorated on error object'
+        )
+      })
     })
 
     it('Does not implement partial migrations', function() {

--- a/test/migrationFailure.js
+++ b/test/migrationFailure.js
@@ -25,14 +25,14 @@ testConfig({
 })
 
 // SQL Server needs 3.25 GB of RAM
-testConfig({
-  migrationDirectory: migrationDirectory,
-  driver: 'mssql',
-  host: 'localhost',
-  database: 'master',
-  username: 'sa',
-  password: 'Postgrator123!'
-})
+// testConfig({
+//   migrationDirectory: migrationDirectory,
+//   driver: 'mssql',
+//   host: 'localhost',
+//   database: 'master',
+//   username: 'sa',
+//   password: 'Postgrator123!'
+// })
 
 function testConfig(config) {
   describe(`Driver: ${config.driver}`, function() {

--- a/test/migrationFailure.js
+++ b/test/migrationFailure.js
@@ -1,0 +1,75 @@
+/* global after, it, describe */
+const assert = require('assert')
+const Postgrator = require('../postgrator')
+
+const path = require('path')
+const migrationDirectory = path.join(__dirname, 'failMigrations')
+
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'pg',
+  host: 'localhost',
+  port: 5432,
+  database: 'postgrator',
+  username: 'postgrator',
+  password: 'postgrator'
+})
+
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'mysql',
+  host: 'localhost',
+  database: 'postgrator',
+  username: 'postgrator',
+  password: 'postgrator'
+})
+
+// SQL Server needs 3.25 GB of RAM
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'mssql',
+  host: 'localhost',
+  database: 'master',
+  username: 'sa',
+  password: 'Postgrator123!'
+})
+
+function testConfig(config) {
+  describe(`Driver: ${config.driver}`, function() {
+    const postgrator = new Postgrator(config)
+
+    let migrations = []
+    let error
+
+    it('Handles failed migrations', function() {
+      return postgrator
+        .migrate()
+        .then(m => {
+          // postgrator.runQuery('SELECT name FROM person')
+          migrations = m
+        })
+        .catch(e => {
+          error = e
+        })
+        .then(() => {
+          assert.equal(migrations.length, 1, 'One migration expected')
+          assert(error, 'an error is expected from bad migration')
+        })
+    })
+
+    it('Does not implement partial migrations', function() {
+      return postgrator.runQuery('SELECT name FROM widgets').then(results => {
+        assert(results.rows)
+        assert.equal(results.rows.length, 0, 'Table should be empty')
+      })
+    })
+
+    it('Migrates down to 000', function() {
+      return postgrator.migrate('00')
+    })
+
+    after(function() {
+      return postgrator.runQuery('DROP TABLE schemaversion')
+    })
+  })
+}

--- a/test/migrations/006.undo.js
+++ b/test/migrations/006.undo.js
@@ -1,0 +1,5 @@
+module.exports.generateSql = function() {
+  return (
+    "DELETE FROM person where name = '" + process.env.TEST_ANOTHER_NAME + "'"
+  )
+}

--- a/test/postgres.js
+++ b/test/postgres.js
@@ -6,15 +6,102 @@ const path = require('path')
 const migrationDirectory = path.join(__dirname, 'migrations')
 const pgUrl = 'tcp://postgrator:postgrator@localhost:5432/postgrator'
 
-const config = {
+testConfig({
   migrationDirectory: migrationDirectory,
   driver: 'pg',
   host: 'localhost',
   port: 5432,
   database: 'postgrator',
   username: 'postgrator',
-  password: 'postgrator',
-  logProgress: false
+  password: 'postgrator'
+})
+
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'mysql',
+  host: 'localhost',
+  database: 'postgrator',
+  username: 'postgrator',
+  password: 'postgrator'
+})
+
+function testConfig(config) {
+  describe(`Config API ${config.driver}`, function() {
+    const postgrator = new Postgrator(config)
+
+    it('Migrates multiple versions up (000 -> 002)', function() {
+      return postgrator
+        .migrate('002')
+        .then(migrations => postgrator.runQuery('SELECT name FROM person'))
+        .then(results => {
+          assert.equal(results.rows.length, 1)
+          return postgrator.endConnection()
+        })
+    })
+
+    it('Handles current version', function() {
+      return postgrator.migrate('002').then(migrations => {
+        assert.equal(migrations.length, 0)
+        return postgrator.endConnection()
+      })
+    })
+
+    it('Migrates one version up (002 -> 003', function() {
+      return postgrator
+        .migrate('003')
+        .then(migrations => postgrator.runQuery('SELECT name FROM person'))
+        .then(results => {
+          assert.equal(results.rows.length, 3)
+          return postgrator.endConnection()
+        })
+    })
+
+    it('Migrates generated SQL', function() {
+      // using this to demo that you use environment variables to generate sql
+      process.env.TEST_NAME = 'aesthete'
+      return postgrator
+        .migrate('005')
+        .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
+        .then(result => {
+          assert.equal(result.rows.length, 5)
+          assert.equal(result.rows[4].name, process.env.TEST_NAME)
+          return postgrator.endConnection()
+        })
+    })
+
+    it('Checksums generated SQL', function() {
+      process.env.TEST_ANOTHER_NAME = 'sop'
+      return postgrator
+        .migrate('006')
+        .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
+        .then(result => {
+          assert.equal(result.rows.length, 6)
+          assert.equal(result.rows[4].name, process.env.TEST_NAME)
+          assert.equal(result.rows[5].name, process.env.TEST_ANOTHER_NAME)
+          return postgrator.endConnection()
+        })
+    })
+
+    it('Migrates to "max"', function() {
+      return postgrator
+        .migrate('max')
+        .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
+        .then(result => {
+          assert.equal(result.rows.length, 6)
+          return postgrator.endConnection()
+        })
+    })
+
+    it('Migrates down to 000', function() {
+      return postgrator.migrate('00').then(() => postgrator.endConnection())
+    })
+
+    it('Drops the schemaversion table', function() {
+      return postgrator
+        .runQuery('DROP TABLE schemaversion')
+        .then(() => postgrator.endConnection())
+    })
+  })
 }
 
 describe('Postgres connection string API', function() {
@@ -36,82 +123,5 @@ describe('Postgres connection string API', function() {
       assert.equal(migrations.length, 3, '3 migrations run')
       return postgrator.endConnection()
     })
-  })
-})
-
-describe('Config API', function() {
-  const postgrator = new Postgrator(config)
-
-  it('Migrates multiple versions up (000 -> 002)', function() {
-    return postgrator
-      .migrate('002')
-      .then(migrations => postgrator.runQuery('SELECT name FROM person'))
-      .then(results => {
-        assert.equal(results.rows.length, 1)
-        return postgrator.endConnection()
-      })
-  })
-
-  it('Handles current version', function() {
-    return postgrator.migrate('002').then(migrations => {
-      assert.equal(migrations.length, 0)
-      return postgrator.endConnection()
-    })
-  })
-
-  it('Migrates one version up (002 -> 003', function() {
-    return postgrator
-      .migrate('003')
-      .then(migrations => postgrator.runQuery('SELECT name FROM person'))
-      .then(results => {
-        assert.equal(results.rows.length, 3)
-        return postgrator.endConnection()
-      })
-  })
-
-  it('Migrates generated SQL', function() {
-    // using this to demo that you use environment variables to generate sql
-    process.env.TEST_NAME = 'aesthete'
-    return postgrator
-      .migrate('005')
-      .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
-      .then(result => {
-        assert.equal(result.rows.length, 5)
-        assert.equal(result.rows[4].name, process.env.TEST_NAME)
-        return postgrator.endConnection()
-      })
-  })
-
-  it('Checksums generated SQL', function() {
-    process.env.TEST_ANOTHER_NAME = 'sop'
-    return postgrator
-      .migrate('006')
-      .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
-      .then(result => {
-        assert.equal(result.rows.length, 6)
-        assert.equal(result.rows[4].name, process.env.TEST_NAME)
-        assert.equal(result.rows[5].name, process.env.TEST_ANOTHER_NAME)
-        return postgrator.endConnection()
-      })
-  })
-
-  it('Migrates to "max"', function() {
-    return postgrator
-      .migrate('max')
-      .then(migrations => postgrator.runQuery('SELECT name, age FROM person'))
-      .then(result => {
-        assert.equal(result.rows.length, 6)
-        return postgrator.endConnection()
-      })
-  })
-
-  it('Migrates down to 000', function() {
-    return postgrator.migrate('00').then(() => postgrator.endConnection())
-  })
-
-  it('Drops the schemaversion table', function() {
-    return postgrator
-      .runQuery('DROP TABLE schemaversion')
-      .then(() => postgrator.endConnection())
   })
 })

--- a/test/postgres.js
+++ b/test/postgres.js
@@ -54,7 +54,6 @@ describe('Config API', function() {
 
   it('Handles current version', function() {
     return postgrator.migrate('002').then(migrations => {
-      console.log(migrations)
       assert.equal(migrations.length, 0)
       return postgrator.endConnection()
     })

--- a/test/postgresConnectionUrl.js
+++ b/test/postgresConnectionUrl.js
@@ -26,8 +26,6 @@ describe('Postgres connection url', function() {
   })
 
   after(function() {
-    return postgrator
-      .runQuery('DROP TABLE schemaversion')
-      .then(() => postgrator.endConnection())
+    return postgrator.runQuery('DROP TABLE schemaversion')
   })
 })

--- a/test/postgresConnectionUrl.js
+++ b/test/postgresConnectionUrl.js
@@ -6,7 +6,7 @@ const path = require('path')
 const migrationDirectory = path.join(__dirname, 'migrations')
 const pgUrl = 'tcp://postgrator:postgrator@localhost:5432/postgrator'
 
-describe('API', function() {
+describe('Postgres connection url', function() {
   const postgrator = new Postgrator({
     driver: 'pg',
     migrationDirectory: migrationDirectory,
@@ -16,32 +16,6 @@ describe('API', function() {
   it('Migrates up to 003', function() {
     return postgrator.migrate('003').then(migrations => {
       assert.equal(migrations.length, 3, '3 migrations run')
-      return postgrator.endConnection()
-    })
-  })
-
-  it('Implements getCurrentVersion', function() {
-    return postgrator.getCurrentVersion().then(currentVersion => {
-      assert.equal(currentVersion, 3)
-      return postgrator.endConnection()
-    })
-  })
-
-  it('Implements getMigrations', function() {
-    return postgrator.getMigrations().then(migrations => {
-      assert.equal(migrations.length, 11)
-      const m = migrations[0]
-      assert.equal(m.version, 1)
-      assert.equal(m.action, 'do')
-      assert.equal(m.filename, '001.do.sql')
-      assert(m.hasOwnProperty('name'))
-      return postgrator.endConnection()
-    })
-  })
-
-  it('Implements getMaxVersion', function() {
-    return postgrator.getMaxVersion().then(max => {
-      assert.equal(max, 6)
       return postgrator.endConnection()
     })
   })

--- a/test/postgresConnectionUrl.js
+++ b/test/postgresConnectionUrl.js
@@ -16,14 +16,12 @@ describe('Postgres connection url', function() {
   it('Migrates up to 003', function() {
     return postgrator.migrate('003').then(migrations => {
       assert.equal(migrations.length, 3, '3 migrations run')
-      return postgrator.endConnection()
     })
   })
 
   it('Migrates down to 000', function() {
     return postgrator.migrate('000').then(migrations => {
       assert.equal(migrations.length, 3, '3 migrations run')
-      return postgrator.endConnection()
     })
   })
 


### PR DESCRIPTION
This is a complete update (practically a rewrite) of postgrator. Tests have been added and all pass. API has changed but migration format has not. 

## Features / Improvements
- `run_at` timestamp column added to schema table
- `md5` and `name` columns added for all implementations
- Checksum validation now implemented for all drivers
- Checksum validation may be skipped using config `validateChecksums: false`
- Callback API replaced with Promises
- Connections opened/closed automatically (no more `.endConnection()`)
- Lots of tests

## Breaking changes
- Node 6 or greater now required
- DB drivers must be installed prior to use (`pg`, `mysql`, `mssql`)
- `pg.js` and `tedious` no longer valid driver config option
- None of the API is the same
- Checksums now validated by default for all drivers
- Calling `.migrate()` without input migrates to latest/max
- Logging to console removed