### PR TITLE
Allow globs for migration file(s) location logic

### DIFF
--- a/postgrator.js
+++ b/postgrator.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const glob = require('glob');
+const glob = require('glob')
 const EventEmitter = require('events')
 
 const commonClient = require('./lib/commonClient.js')
@@ -41,16 +41,21 @@ class Postgrator extends EventEmitter {
       }
       if (migrationPattern) {
         glob(migrationPattern, loader)
-      } else if(migrationDirectory) {
+      } else if (migrationDirectory) {
         fs.readdir(migrationDirectory, loader)
       } else {
         resolve([])
       }
     }).then(migrationFiles => {
       migrationFiles.forEach(file => {
-        const m = file.split('.')
+        const m = file
+          .split('/')
+          .pop()
+          .split('.')
         const name = m.length >= 3 ? m.slice(2, m.length - 1).join('.') : file
-        const filename = path.join(migrationDirectory, file)
+        const filename = migrationPattern
+          ? file
+          : path.join(migrationDirectory, file)
         if (m[m.length - 1] === 'sql') {
           this.migrations.push({
             version: Number(m[0]),

--- a/test/api.js
+++ b/test/api.js
@@ -57,6 +57,20 @@ describe('API', function() {
     })
   })
 
+  it('finds migrations by glob pattern', function() {
+    const patterngrator = new Postgrator({
+      driver: 'pg',
+      migrationPattern: `${__dirname}/fail*/*`,
+      connectionString: pgUrl
+    })
+    patterngrator
+      .getMigrations()
+      .then(migrationsByPattern => {
+        assert.equal(migrationsByPattern.length, 4, '4 migrations run')
+      })
+      .catch(err => console.log(err))
+  })
+
   it('Implements getMaxVersion', function() {
     return postgrator.getMaxVersion().then(max => {
       assert.equal(max, 6)

--- a/test/api.js
+++ b/test/api.js
@@ -57,7 +57,7 @@ describe('API', function() {
     })
   })
 
-  it('finds migrations by glob pattern', function() {
+  it('Finds migrations by glob pattern', function() {
     const patterngrator = new Postgrator({
       driver: 'pg',
       migrationPattern: `${__dirname}/fail*/*`,
@@ -66,7 +66,7 @@ describe('API', function() {
     patterngrator
       .getMigrations()
       .then(migrationsByPattern => {
-        assert.equal(migrationsByPattern.length, 4, '4 migrations run')
+        assert.equal(migrationsByPattern.length, 4)
       })
       .catch(err => console.log(err))
   })


### PR DESCRIPTION
Adds a `migrationPattern` option that can be used as a glob pattern for locating migration files, rather than requiring a single directory for migrations.