### PR TITLE
Consider schema/database in ensureTable check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,12 @@ services:
       MYSQL_PASSWORD: postgrator
     ports:
       - "3306:3306"
-  # SQL Server needs 3.25 GB of RAM
-  # sqlserver:
-  #   image: microsoft/mssql-server-linux:latest
-  #   environment:
-  #     ACCEPT_EULA: Y 
-  #     SA_PASSWORD: Postgrator123!
-  #     MSSQL_PID: Express
-  #   ports:
-  #     - "1433:1433"
+  # SQL Server needs 2.00 GB of RAM
+  sqlserver:
+    image: microsoft/mssql-server-linux:latest
+    environment:
+      ACCEPT_EULA: Y 
+      SA_PASSWORD: Postgrator123!
+      MSSQL_PID: Express
+    ports:
+      - "1433:1433"

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -92,11 +92,15 @@ module.exports = function(config) {
     let columnKeyword = 'COLUMN'
 
     if (config.driver === 'pg') {
+      const schemaSql = config.database
+        ? `AND table_catalog = '${config.database}'`
+        : ''
+
       sql = `
         SELECT column_name
         FROM INFORMATION_SCHEMA.COLUMNS 
         WHERE table_name = '${config.schemaTable}'
-        AND table_catalog = '${config.database}';
+        ${schemaSql};
       `
     } else if (config.driver === 'mssql') {
       textType = 'VARCHAR(MAX)'

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -87,11 +87,35 @@ module.exports = function(config) {
   }
 
   commonClient.ensureTable = () => {
-    const sql = `
-      SELECT column_name
-      FROM INFORMATION_SCHEMA.COLUMNS 
-      WHERE table_name = '${config.schemaTable}';
-    `
+    let sql = ''
+    let textType = 'TEXT'
+    let columnKeyword = 'COLUMN'
+
+    if (config.driver === 'pg') {
+      sql = `
+        SELECT column_name
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE table_name = '${config.schemaTable}'
+        AND table_catalog = '${config.database}';
+      `
+    } else if (config.driver === 'mssql') {
+      textType = 'VARCHAR(MAX)'
+      columnKeyword = ''
+      sql = `
+        SELECT column_name
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE table_name = '${config.schemaTable}'
+        AND table_catalog = '${config.database}';
+      `
+    } else if (config.driver === 'mysql') {
+      sql = `
+        SELECT column_name
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE table_name = '${config.schemaTable}'
+        AND table_schema = '${config.database}';
+      `
+    }
+
     return commonClient.runQuery(sql).then(results => {
       const sqls = []
       if (results.rows.length === 0) {
@@ -103,8 +127,6 @@ module.exports = function(config) {
             VALUES (0);
         `)
       }
-      const textType = config.driver === 'mssql' ? 'VARCHAR(MAX)' : 'TEXT'
-      const columnKeyword = config.driver === 'mssql' ? '' : 'COLUMN'
       if (!results.rows.find(row => row.column_name === 'name')) {
         sqls.push(
           `ALTER TABLE ${config.schemaTable} ADD ${columnKeyword} name ${

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "lint": "eslint '**/*.js'",
-    "test": "mocha"
+    "test": "mocha --recursive"
   },
   "dependencies": {
     "glob": "^7.1.2",

--- a/test/drivers/driverIntegration.js
+++ b/test/drivers/driverIntegration.js
@@ -1,40 +1,8 @@
 /* global after, it, describe */
 const assert = require('assert')
-const Postgrator = require('../postgrator')
+const Postgrator = require('../../postgrator')
 
-const path = require('path')
-const migrationDirectory = path.join(__dirname, 'migrations')
-
-testConfig({
-  migrationDirectory: migrationDirectory,
-  driver: 'pg',
-  host: 'localhost',
-  port: 5432,
-  database: 'postgrator',
-  username: 'postgrator',
-  password: 'postgrator'
-})
-
-testConfig({
-  migrationDirectory: migrationDirectory,
-  driver: 'mysql',
-  host: 'localhost',
-  database: 'postgrator',
-  username: 'postgrator',
-  password: 'postgrator'
-})
-
-// SQL Server needs 3.25 GB of RAM
-// testConfig({
-//   migrationDirectory: migrationDirectory,
-//   driver: 'mssql',
-//   host: 'localhost',
-//   database: 'master',
-//   username: 'sa',
-//   password: 'Postgrator123!'
-// })
-
-function testConfig(config) {
+module.exports = function testConfig(config) {
   describe(`Driver: ${config.driver}`, function() {
     const postgrator = new Postgrator(config)
 

--- a/test/drivers/mssql.js
+++ b/test/drivers/mssql.js
@@ -1,0 +1,12 @@
+const path = require('path')
+const testConfig = require('./driverIntegration')
+
+// SQL Server needs 2 GB of RAM
+testConfig({
+  migrationDirectory: path.join(__dirname, '../migrations'),
+  driver: 'mssql',
+  host: 'localhost',
+  database: 'master',
+  username: 'sa',
+  password: 'Postgrator123!'
+})

--- a/test/drivers/mysql.js
+++ b/test/drivers/mysql.js
@@ -1,0 +1,11 @@
+const path = require('path')
+const testConfig = require('./driverIntegration')
+
+testConfig({
+  migrationDirectory: path.join(__dirname, '../migrations'),
+  driver: 'mysql',
+  host: 'localhost',
+  database: 'postgrator',
+  username: 'postgrator',
+  password: 'postgrator'
+})

--- a/test/drivers/pg.js
+++ b/test/drivers/pg.js
@@ -1,0 +1,12 @@
+const path = require('path')
+const testConfig = require('./driverIntegration')
+
+testConfig({
+  migrationDirectory: path.join(__dirname, '../migrations'),
+  driver: 'pg',
+  host: 'localhost',
+  port: 5432,
+  database: 'postgrator',
+  username: 'postgrator',
+  password: 'postgrator'
+})


### PR DESCRIPTION
Adds consideration for the database/schema being operated on. This enhances support for having multiple databases/schemas being managed via postgrator on a single cluster.

For postgres, this implementation requires that the db connection info be passed in as an object, not a connection string. (that can come later - it'll require parsing the connection string to get the database name)

closes #48 