### PR TITLE
Add TypeScript definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,30 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "9.4.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
+      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "dev": true
+    },
+    "@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
+      "dev": true
+    },
+    "@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true
+    },
     "acorn": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
@@ -935,6 +959,15 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -1557,6 +1590,12 @@
         "yallist": "2.1.2"
       }
     },
+    "make-error": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.3.tgz",
+      "integrity": "sha512-j3dZCri3cCd23wgPqK/0/KvTN8R+W6fXDqQe8BNLbTpONjbA8SPaRr+q0BQq9bx3Q/+g68/gDIh9FW3by702Tg==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
@@ -1876,6 +1915,12 @@
       "requires": {
         "error-ex": "1.3.1"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "path-exists": {
       "version": "2.1.0",
@@ -2282,6 +2327,21 @@
         "is-fullwidth-code-point": "2.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+      "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.6.1"
+      }
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -2480,6 +2540,44 @@
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
+    "ts-node": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
+      "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "2.3.0",
+        "diff": "3.3.1",
+        "make-error": "1.3.3",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.3",
+        "tsconfig": "7.0.0",
+        "v8flags": "3.0.1",
+        "yn": "2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
+      "requires": {
+        "@types/strip-bom": "3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1"
+      }
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -2495,11 +2593,26 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "v8flags": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
+      "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -2550,6 +2663,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "url": "git://github.com/rickbergfalk/postgrator.git"
   },
   "main": "postgrator",
+  "types": "postgrator.d.ts",
   "devDependencies": {
     "eslint": "^4.10.0",
     "eslint-config-prettier": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "lint": "eslint '**/*.js'",
-    "test": "mocha --recursive"
+    "test": "mocha --require ts-node/register --recursive \"test/**/*.{js,ts}\""
   },
   "dependencies": {
     "glob": "^7.1.2",
@@ -42,6 +42,8 @@
   "main": "postgrator",
   "types": "postgrator.d.ts",
   "devDependencies": {
+    "@types/mocha": "^2.2.48",
+    "@types/node": "^9.4.6",
     "eslint": "^4.10.0",
     "eslint-config-prettier": "^2.7.0",
     "eslint-config-standard": "^10.2.1",
@@ -55,6 +57,8 @@
     "mssql": "^4.1.0",
     "mysql": "^2.15.0",
     "pg": "^7.4.1",
-    "prettier": "^1.7.4"
+    "prettier": "^1.7.4",
+    "ts-node": "^4.1.0",
+    "typescript": "^2.7.1"
   }
 }

--- a/postgrator.d.ts
+++ b/postgrator.d.ts
@@ -73,6 +73,12 @@ declare namespace Postgrator {
 
   type Options = PostgreSQLOptions | MySQLOptions | MsSQLOptions
 
+  /**
+   * A migration event handler
+   *
+   * @param migration the migration object representing this event
+   */
+  export type MigrationEventCallback = (migration: Postgrator.Migration) => void
 }
 
 declare class Postgrator {
@@ -145,7 +151,39 @@ declare class Postgrator {
    * @returns
    * @param target version to migrate as string or number (handled as  numbers internally)
    */
-  migrate(target?: string): Promise<Postgrator.QueryResult>
+  migrate(target?: string): Promise<any>
+
+  /**
+   * Registers an event lister for the `validation-started` event
+   *
+   * @param event the event name
+   * @param cb the callback to handle the event
+   */
+  on(event: 'validation-started', cb: Postgrator.MigrationEventCallback): void
+
+  /**
+   * Registers an event lister for the `validation-finished` event
+   *
+   * @param event the event name
+   * @param cb the callback to handle the event
+   */
+  on(event: 'validation-finished', cb: Postgrator.MigrationEventCallback): void
+
+  /**
+   * Registers an event lister for the `migration-started` event
+   *
+   * @param event the event name
+   * @param cb the callback to handle the event
+   */
+  on(event: 'migration-started', cb: Postgrator.MigrationEventCallback): void
+
+  /**
+   * Registers an event lister for the `migration-finished` event
+   *
+   * @param event the event name
+   * @param cb the callback to handle the event
+   */
+  on(event: 'migration-finished', cb: Postgrator.MigrationEventCallback): void
 }
 
 export = Postgrator

--- a/postgrator.d.ts
+++ b/postgrator.d.ts
@@ -1,0 +1,151 @@
+declare namespace Postgrator {
+
+  /**
+   * A common query object
+   */
+  export interface QueryResult {
+    rows: any[]
+    fields: any
+  }
+
+  /**
+   * A migration object
+   */
+  export interface Migration {
+    version: number
+    action: 'do' | 'undo'
+    filename: string
+    name: string
+    md5: string
+    getSql: () => string
+  }
+
+  export interface BaseOptions {
+    schemaTable?: string
+    validateChecksums?: boolean
+    migrationDirectory?: string
+    migrationPattern?: string
+    newline?: string
+  }
+
+  /**
+   * Configuration options for MySQL connections
+   */
+  export interface MySQLOptions extends BaseOptions {
+    driver: 'mysql'
+    host?: string
+    port?: string | number
+    username: string
+    password: string
+    database?: string
+  }
+
+  /**
+   * Configuration options for PostgreSQL connections
+   */
+  export interface PostgreSQLOptions extends BaseOptions {
+    driver: 'pg'
+    ssl?: boolean
+    connectionString?: string
+    host?: string
+    port?: string | number
+    user?: string
+    username?: string
+    password?: string
+    database?: string
+  }
+
+  /**
+   * Configuration options for Microsoft SQL Server connections
+   */
+  export interface MsSQLOptions extends BaseOptions {
+    driver: 'mssql'
+    ssl?: boolean
+    connectionString?: string
+    host: string
+    port: string | number
+    username: string
+    password: string
+    database: string
+    options?: any
+    requestTimeout?: number
+  }
+
+  type Options = PostgreSQLOptions | MySQLOptions | MsSQLOptions
+
+}
+
+declare class Postgrator {
+  /**
+   * Creates an instance of the postgrator class
+   * @param options Configuration options
+   */
+  constructor(options: Postgrator.Options)
+
+  /**
+   * Reads all migrations from directory
+   *
+   * @returns array of migration objects
+   */
+  getMigrations(): Promise<Postgrator.Migration[]>
+
+  /**
+   * Executes sql query using the common client and ends connection afterwards
+   *
+   * @returns result of query
+   * @param query sql query to execute
+   */
+  runQuery(query: string): Promise<Postgrator.QueryResult>
+
+  /**
+   * Gets the database version of the schema from the database.
+   * Otherwise 0 if no version has been run
+   *
+   * @returns database schema version
+   */
+  getDatabaseVersion(): Promise<number>
+
+  /**
+   * Returns an object with max version of migration available
+   *
+   * @returns
+   */
+  getMaxVersion(): Promise<number>
+
+  /**
+   * Validate md5 checksums for applied migrations
+   *
+   * @returns
+   * @param databaseVersion
+   */
+  validateMigrations(databaseVersion: number): Promise<undefined>
+
+  /**
+   * Runs the migrations in the order to reach target version
+   *
+   * @returns Array of migration objects to appled to database
+   * @param migrations Array of migration objects to apply to database
+   */
+  runMigrations(migrations?: Postgrator.Migration[]): Promise<Postgrator.Migration[]>
+
+  /**
+   * returns an array of relevant migrations based on the target and database version passed.
+   * returned array is sorted in the order it needs to be run
+   *
+   * @returns Sorted array of relevant migration objects
+   * @param databaseVersion
+   * @param targetVersion
+   */
+  getRunnableMigrations(databaseVersion: number, targetVersion: number): Postgrator.Migration[]
+
+  /**
+   * Main method to move a schema to a particular version.
+   * A target must be specified, otherwise nothing is run.
+   *
+   * @returns
+   * @param target version to migrate as string or number (handled as  numbers internally)
+   */
+  migrate(target?: string): Promise<Postgrator.QueryResult>
+}
+
+export = Postgrator

--- a/postgrator.d.ts
+++ b/postgrator.d.ts
@@ -1,7 +1,7 @@
 declare namespace Postgrator {
 
   /**
-   * A common query object
+   * A common query result
    */
   export interface QueryResult {
     rows: any[]
@@ -151,7 +151,7 @@ declare class Postgrator {
    * @returns
    * @param target version to migrate as string or number (handled as  numbers internally)
    */
-  migrate(target?: string): Promise<any>
+  migrate(target?: string): Promise<Postgrator.Migration[]>
 
   /**
    * Registers an event lister for the `validation-started` event

--- a/postgrator.d.ts
+++ b/postgrator.d.ts
@@ -69,6 +69,7 @@ declare namespace Postgrator {
     database: string
     options?: any
     requestTimeout?: number
+    connectionTimeout?: number
   }
 
   type Options = PostgreSQLOptions | MySQLOptions | MsSQLOptions

--- a/test/api.ts
+++ b/test/api.ts
@@ -1,0 +1,88 @@
+import * as assert from 'assert'
+import * as Postgrator from '../'
+
+import * as path from 'path'
+const migrationDirectory = path.join(__dirname, 'migrations')
+const pgUrl = 'tcp://postgrator:postgrator@localhost:5432/postgrator'
+
+describe('TypeScript:API', function() {
+  const postgrator = new Postgrator({
+    driver: 'pg',
+    migrationDirectory: migrationDirectory,
+    connectionString: pgUrl
+  })
+
+  const vStarted: Postgrator.Migration[] = []
+  const vFinished: Postgrator.Migration[] = []
+  const mStarted: Postgrator.Migration[] = []
+  const mFinished: Postgrator.Migration[] = []
+  postgrator.on('validation-started', migration => vStarted.push(migration))
+  postgrator.on('validation-finished', migration => vFinished.push(migration))
+  postgrator.on('migration-started', migration => mStarted.push(migration))
+  postgrator.on('migration-finished', migration => mFinished.push(migration))
+
+  it('Migrates up to 003', function() {
+    return postgrator.migrate('003').then(migrations => {
+      assert.equal(migrations.length, 3, '3 migrations run')
+    })
+  })
+
+  it('Emits migration events', function() {
+    assert.equal(mStarted.length, 3)
+    assert.equal(mFinished.length, 3)
+  })
+
+  it('Emits validation events', function() {
+    return postgrator.migrate('004').then(migrations => {
+      assert.equal(vStarted.length, 3)
+      assert.equal(vFinished.length, 3)
+    })
+  })
+
+  it('Implements getDatabaseVersion', function() {
+    return postgrator.getDatabaseVersion().then(version => {
+      assert.equal(version, 4)
+    })
+  })
+
+  it('Implements getMigrations', function() {
+    return postgrator.getMigrations().then(migrations => {
+      assert.equal(migrations.length, 12)
+      const m = migrations[0]
+      assert.equal(m.version, 1)
+      assert.equal(m.action, 'do')
+      assert.equal(m.filename, '001.do.sql')
+      assert(m.hasOwnProperty('name'))
+    })
+  })
+
+  it('Finds migrations by glob pattern', function() {
+    const patterngrator = new Postgrator({
+      driver: 'pg',
+      migrationPattern: `${__dirname}/fail*/*`,
+      connectionString: pgUrl
+    })
+    patterngrator
+      .getMigrations()
+      .then(migrationsByPattern => {
+        assert.equal(migrationsByPattern.length, 4)
+      })
+      .catch(err => console.log(err))
+  })
+
+  it('Implements getMaxVersion', function() {
+    return postgrator.getMaxVersion().then(max => {
+      assert.equal(max, 6)
+    })
+  })
+
+  it('Migrates down to 000', function() {
+    return postgrator.migrate('000').then(migrations => {
+      assert.equal(migrations.length, 4, '4 migrations run')
+    })
+  })
+
+  after(function() {
+    return postgrator.runQuery('DROP TABLE schemaversion')
+  })
+})

--- a/test/api.ts
+++ b/test/api.ts
@@ -21,68 +21,58 @@ describe('TypeScript:API', function() {
   postgrator.on('migration-started', migration => mStarted.push(migration))
   postgrator.on('migration-finished', migration => mFinished.push(migration))
 
-  it('Migrates up to 003', function() {
-    return postgrator.migrate('003').then(migrations => {
-      assert.equal(migrations.length, 3, '3 migrations run')
-    })
+  it('Migrates up to 003', async () => {
+    const migrations: Postgrator.Migration[] = await postgrator.migrate('003')
+    assert.equal(migrations.length, 3, '3 migrations run')
   })
 
-  it('Emits migration events', function() {
+  it('Emits migration events', () => {
     assert.equal(mStarted.length, 3)
     assert.equal(mFinished.length, 3)
   })
 
-  it('Emits validation events', function() {
-    return postgrator.migrate('004').then(migrations => {
-      assert.equal(vStarted.length, 3)
-      assert.equal(vFinished.length, 3)
-    })
+  it('Emits validation events', async () => {
+    const migrations: Postgrator.Migration[] = await postgrator.migrate('004')
+    assert.equal(vStarted.length, 3)
+    assert.equal(vFinished.length, 3)
   })
 
-  it('Implements getDatabaseVersion', function() {
-    return postgrator.getDatabaseVersion().then(version => {
-      assert.equal(version, 4)
-    })
+  it('Implements getDatabaseVersion', async () => {
+    const version: number = await postgrator.getDatabaseVersion()
+    assert.equal(version, 4)
   })
 
-  it('Implements getMigrations', function() {
-    return postgrator.getMigrations().then(migrations => {
-      assert.equal(migrations.length, 12)
-      const m = migrations[0]
-      assert.equal(m.version, 1)
-      assert.equal(m.action, 'do')
-      assert.equal(m.filename, '001.do.sql')
-      assert(m.hasOwnProperty('name'))
-    })
+  it('Implements getMigrations', async () => {
+    const migrations: Postgrator.Migration[] = await postgrator.getMigrations()
+    assert.equal(migrations.length, 12)
+    const m = migrations[0]
+    assert.equal(m.version, 1)
+    assert.equal(m.action, 'do')
+    assert.equal(m.filename, '001.do.sql')
+    assert(m.hasOwnProperty('name'))
   })
 
-  it('Finds migrations by glob pattern', function() {
+  it('Finds migrations by glob pattern', async () => {
     const patterngrator = new Postgrator({
       driver: 'pg',
       migrationPattern: `${__dirname}/fail*/*`,
       connectionString: pgUrl
     })
-    patterngrator
-      .getMigrations()
-      .then(migrationsByPattern => {
-        assert.equal(migrationsByPattern.length, 4)
-      })
-      .catch(err => console.log(err))
+    const migrationsByPattern: Postgrator.Migration[] = await patterngrator.getMigrations()
+    assert.equal(migrationsByPattern.length, 4)
   })
 
-  it('Implements getMaxVersion', function() {
-    return postgrator.getMaxVersion().then(max => {
-      assert.equal(max, 6)
-    })
+  it('Implements getMaxVersion', async () => {
+    const max: number = await postgrator.getMaxVersion()
+    assert.equal(max, 6)
   })
 
-  it('Migrates down to 000', function() {
-    return postgrator.migrate('000').then(migrations => {
-      assert.equal(migrations.length, 4, '4 migrations run')
-    })
+  it('Migrates down to 000', async () => {
+    const migrations: Postgrator.Migration[] = await postgrator.migrate('000')
+    assert.equal(migrations.length, 4, '4 migrations run')
   })
 
-  after(function() {
+  after((): Promise<Postgrator.QueryResult> => {
     return postgrator.runQuery('DROP TABLE schemaversion')
   })
 })

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["es7"],
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "types": ["node", "mocha"]
+  }
+}


### PR DESCRIPTION
This PR adds a bundled type definitions file to allow consumers using TypeScript to use the package without having to manually declare the main export as `any` or take extra effort to define the types themselves.

The benefit of this is also one of developer tooling, where users of editors which integrate the TypeScript server (such as VSCode) will see hints such as this:

![image](https://user-images.githubusercontent.com/5011956/36077064-c420ae02-0f5d-11e8-8a54-a75972c28de3.png)

If you disagree with directly bundling this definition file, I can close this PR and create a new [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) respository that mirrors this one for developers who wish to install the types explicitly with `npm install @types/postgrator`.

It's up to you if you are OK with the typed being bundled here - the drawback of this is that the types definition file _must_ be updated to reflect the JavaScript code, each time it is changed. I'll gladly help with this, but this does take time and effort. The alternative suggestion has the same issue, but it's generally more accepted that outdated types are monkey-patched when required.