### PR TITLE
preserve connection timeout config for mssql

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ This may be necessary if requiring a secure connection for Azure.
 ```js
 const postgrator = new Postgrator({
   requestTimeout: 1000 * 60 * 60, // Default 1 hour
+  connectionTimeout: 30000 // override mssql 15 second default
   options: {
     encrypt: true
   }

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -279,6 +279,7 @@ function createMssql(config, commonClient) {
     database: config.database,
     options: config.options,
     requestTimeout: config.requestTimeout || oneHour,
+    connectionTimeout: config.connectionTimeout || 15000,
     pool: {
       max: 1,
       min: 1


### PR DESCRIPTION
pass down `postGratorConfig.connectionTimeout` through to MSSQL to allow override of 15 second default