### PR TITLE
When using pg, create a schema when schemaTable specifies one

### DIFF
--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -92,14 +92,26 @@ module.exports = function(config) {
     let columnKeyword = 'COLUMN'
 
     if (config.driver === 'pg') {
-      const schemaSql = config.database
+      const tableCatalogSql = config.database
         ? `AND table_catalog = '${config.database}'`
         : ''
+
+      // When using pg, if schemaTable has a `.` in it, use it as a
+      // schema name.
+      const schema = config.schemaTable.split('.')
+      let tableName = schema[0]
+      let schemaSql = ''
+
+      if (schema[1]) {
+        tableName = schema[1]
+        schemaSql = `AND table_schema = '${schema[0]}'`
+      }
 
       sql = `
         SELECT column_name
         FROM INFORMATION_SCHEMA.COLUMNS 
-        WHERE table_name = '${config.schemaTable}'
+        WHERE table_name = '${tableName}'
+        ${tableCatalogSql}
         ${schemaSql};
       `
     } else if (config.driver === 'mssql') {
@@ -123,6 +135,14 @@ module.exports = function(config) {
     return commonClient.runQuery(sql).then(results => {
       const sqls = []
       if (results.rows.length === 0) {
+        if (config.driver === 'pg') {
+          // When using pg, create a schema if schemaTable has a `.` in it
+          const schema = config.schemaTable.split('.')
+          if (schema[1]) {
+            sqls.push(`CREATE SCHEMA IF NOT EXISTS ${schema[0]};`)
+          }
+        }
+
         sqls.push(`
           CREATE TABLE ${config.schemaTable} (
             version BIGINT PRIMARY KEY

--- a/test/drivers/driverIntegration.js
+++ b/test/drivers/driverIntegration.js
@@ -2,8 +2,8 @@
 const assert = require('assert')
 const Postgrator = require('../../postgrator')
 
-module.exports = function testConfig(config) {
-  describe(`Driver: ${config.driver}`, function() {
+module.exports = function testConfig(config, label) {
+  describe(label || `Driver: ${config.driver}`, function() {
     const postgrator = new Postgrator(config)
 
     it('Migrates multiple versions up (000 -> 002)', function() {
@@ -22,10 +22,11 @@ module.exports = function testConfig(config) {
     })
 
     it('Has migration details in schema table', function() {
+      const schemaTable = config.schemaTable || 'schemaversion'
       return postgrator
         .runQuery(
           `SELECT version, name, md5, run_at 
-          FROM schemaversion 
+          FROM ${schemaTable}
           WHERE version = 2`
         )
         .then(results => {

--- a/test/drivers/pg.js
+++ b/test/drivers/pg.js
@@ -10,3 +10,17 @@ testConfig({
   username: 'postgrator',
   password: 'postgrator'
 })
+
+testConfig(
+  {
+    migrationDirectory: path.join(__dirname, '../migrations'),
+    driver: 'pg',
+    host: 'localhost',
+    port: 5432,
+    database: 'postgrator',
+    username: 'postgrator',
+    password: 'postgrator',
+    schemaTable: 'postgrator.schemaversion'
+  },
+  'Driver: pg (with schema)'
+)


### PR DESCRIPTION
When using pg, create a schema when schemaTable specifies one.  `schemaversion` will work just as it does now, but `postgrator.schemaversion` will place the table in the `postgrator` schema, creating it if it doesn't exist.

I've updated the tests to use `postgrator.schemaversion`.