### PR TITLE
Add support for SSL connections to MySQL databases

### DIFF
--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -200,7 +200,8 @@ function createMysql(config, commonClient) {
         port: config.port,
         user: config.username,
         password: config.password,
-        database: config.database
+        database: config.database,
+        ssl: config.ssl
       })
       commonClient.dbConnection = connection
       connection.connect(err => {


### PR DESCRIPTION
Firstly, nice lib!

I think a pretty common use case is people running MySQL RDS instances - which require SSL connections. Unfortunately the config for MySQL is explicitly defined and so it's currently impossible to create an SSL connection to MySQL instances.

To solve this, we can just pass the ssl config directly through to the `createConnection` call.

https://github.com/mysqljs/mysql#connection-options

Another solution might be to pass the _entire_ config block without redefining it, and thereby allow the user to have control over everything that isn't necessary for Postgrator to function correctly (if anything, they can just be overridden).