### PR TITLE
Compatibility updates

### DIFF
--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -1,6 +1,11 @@
 const utils = require('./utils')
 
-const DRIVERS = ['pg', 'mysql', 'mssql']
+const DRIVERS = [
+  { package: 'pg', min: 6, max: 7 },
+  { package: 'mysql', min: 2, max: 2 },
+  { package: 'mysql2', min: 1, max: 1 },
+  { package: 'mssql', min: 4, max: 4 }
+]
 
 const TIMESTAMP_TYPES = {
   pg: 'TIMESTAMP WITH TIME ZONE',
@@ -9,11 +14,17 @@ const TIMESTAMP_TYPES = {
 }
 
 module.exports = function(config) {
-  if (DRIVERS.indexOf(config.driver) === -1) {
+  const driver = DRIVERS.find(({ package }) => package === config.driver)
+
+  if (!driver) {
     throw new Error(
-      'db driver not supported. Must one of: ' + DRIVERS.join(', ')
+      `db driver '${config.driver}' not supported. Must one of: '${DRIVERS.map(
+        x => x.package
+      ).join("', '")}'`
     )
   }
+
+  utils.supportWarning(driver.package, driver.min, driver.max)
 
   const commonClient = {
     connected: false,
@@ -190,7 +201,6 @@ function createMysql(config, commonClient) {
     console.error('Did you forget to run "npm install mysql"?')
     throw e
   }
-  utils.supportWarning('mysql', 2, 2)
 
   commonClient._createConnection = () => {
     return new Promise((resolve, reject) => {
@@ -243,7 +253,6 @@ function createPostgres(config, commonClient) {
     console.error('Did you forget to run "npm install pg"?')
     throw e
   }
-  utils.supportWarning('pg', 6, 7)
 
   if (config.ssl) {
     commonClient.dbDriver.defaults.ssl = true
@@ -287,7 +296,6 @@ function createMssql(config, commonClient) {
     console.error('Did you forget to run "npm install mssql"?')
     throw e
   }
-  utils.supportWarning('mssql', 4, 4)
 
   const oneHour = 1000 * 60 * 60
 

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -208,7 +208,7 @@ function createMysql(config, commonClient) {
         multipleStatements: true,
         host: config.host,
         port: config.port,
-        user: config.username,
+        user: config.username || config.user,
         password: config.password,
         database: config.database
       })

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -69,7 +69,7 @@ module.exports = function(config) {
     }
   }
 
-  if (config.driver === 'mysql') {
+  if (config.driver === 'mysql' || config.driver === 'mysql2') {
     createMysql(config, commonClient)
   } else if (config.driver === 'pg') {
     createPostgres(config, commonClient)
@@ -196,9 +196,9 @@ module.exports = function(config) {
 
 function createMysql(config, commonClient) {
   try {
-    commonClient.dbDriver = require('mysql')
+    commonClient.dbDriver = require(config.driver)
   } catch (e) {
-    console.error('Did you forget to run "npm install mysql"?')
+    console.error(`Did you forget to run "npm install ${config.driver}"?`)
     throw e
   }
 


### PR DESCRIPTION
1. Pass through `user` config prop (if `username` is empty).
- mysql expects 'user', so using the mysql driver requires the consumer to remap the prop name, which we then also remap again internally.

2. Allow `mysql2` package as a valid mysql driver. It's API compatible, more performant and uses native promises out of the box.
- Consumers of postgrator who are using mysql are probably using `mysql2` already, so forcing them to also grab the `mysql` as well is a bit annoying.
- This also necessitated moving the `utils.supportWarning` to outside of the driver creation functions, but made driver-validation rules somewhat more declarative as well.
