### PR TITLE
End connection error

### DIFF
--- a/postgrator.js
+++ b/postgrator.js
@@ -275,7 +275,14 @@ class Postgrator extends EventEmitter {
         if (!error.appliedMigrations) {
           error.appliedMigrations = []
         }
-        throw error
+
+        // Attempt to close connection then throw original error
+        return commonClient
+          .endConnection()
+          .catch(() => {})
+          .then(() => {
+            throw error
+          })
       })
   }
 }

--- a/test/migrationFailure.js
+++ b/test/migrationFailure.js
@@ -24,15 +24,14 @@ testConfig({
   password: 'postgrator'
 })
 
-// SQL Server needs 3.25 GB of RAM
-// testConfig({
-//   migrationDirectory: migrationDirectory,
-//   driver: 'mssql',
-//   host: 'localhost',
-//   database: 'master',
-//   username: 'sa',
-//   password: 'Postgrator123!'
-// })
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'mssql',
+  host: 'localhost',
+  database: 'master',
+  username: 'sa',
+  password: 'Postgrator123!'
+})
 
 function testConfig(config) {
   describe(`Driver: ${config.driver}`, function() {
@@ -44,6 +43,11 @@ function testConfig(config) {
         assert(
           error.appliedMigrations,
           'appliedMigrations decorated on error object'
+        )
+        assert.strictEqual(
+          postgrator.commonClient.connected,
+          false,
+          'client disconnected on error'
         )
       })
     })


### PR DESCRIPTION
Ends connection on encountering a failed migration. Previously the connection would be left open, leaving scripts/applications hanging. 

closes #58 