### PR TITLE
Clean up .getMigrations()

### DIFF
--- a/postgrator.js
+++ b/postgrator.js
@@ -61,8 +61,8 @@ class Postgrator extends EventEmitter {
 
           // TODO normalize filename on returned migration object
           // Today it is full path if glob is used, otherwise basename with extension
-          // This is not persisted.
-          // Some people may be using this, so it technically will be a breaking fix
+          // This is not persisted in the database, but this field might be a part of someone's workflow
+          // Making this change will be a breaking fix
 
           if (ext === '.sql') {
             return {

--- a/postgrator.js
+++ b/postgrator.js
@@ -31,7 +31,6 @@ class Postgrator extends EventEmitter {
    */
   getMigrations() {
     const { migrationDirectory, migrationPattern, newline } = this.config
-    this.migrations = []
     return new Promise((resolve, reject) => {
       const loader = (err, files) => {
         if (err) {
@@ -46,43 +45,58 @@ class Postgrator extends EventEmitter {
       } else {
         resolve([])
       }
-    }).then(migrationFiles => {
-      migrationFiles.forEach(file => {
-        const m = file
-          .split('/')
-          .pop()
-          .split('.')
-        const name = m.length >= 3 ? m.slice(2, m.length - 1).join('.') : file
-        const filename = migrationPattern
-          ? file
-          : path.join(migrationDirectory, file)
-        if (m[m.length - 1] === 'sql') {
-          this.migrations.push({
-            version: Number(m[0]),
-            action: m[1],
-            filename: file,
-            name: name,
-            md5: fileChecksum(filename, newline),
-            getSql: () => fs.readFileSync(filename, 'utf8')
-          })
-        } else if (m[m.length - 1] === 'js') {
-          const jsModule = require(filename)
-          const sql = jsModule.generateSql()
-          this.migrations.push({
-            version: Number(m[0]),
-            action: m[1],
-            filename: file,
-            name: name,
-            md5: checksum(sql, newline),
-            getSql: () => sql
-          })
-        }
-      })
-      this.migrations = this.migrations.filter(
-        migration => !isNaN(migration.version)
-      )
-      return this.migrations
     })
+      .then(migrationFiles => {
+        return migrationFiles.map(file => {
+          const basename = path.basename(file)
+          const ext = path.extname(basename)
+
+          const basenameNoExt = path.basename(file, ext)
+          let [version, action, name = ''] = basenameNoExt.split('.')
+          version = Number(version)
+
+          const filename = migrationPattern
+            ? file
+            : path.join(migrationDirectory, file)
+
+          // TODO normalize filename on returned migration object
+          // Today it is full path if glob is used, otherwise basename with extension
+          // This is not persisted.
+          // Some people may be using this, so it technically will be a breaking fix
+
+          if (ext === '.sql') {
+            return {
+              version,
+              action,
+              filename: file,
+              name,
+              md5: fileChecksum(filename, newline),
+              getSql: () => fs.readFileSync(filename, 'utf8')
+            }
+          }
+
+          if (ext === '.js') {
+            const jsModule = require(filename)
+            const sql = jsModule.generateSql()
+
+            return {
+              version,
+              action,
+              filename: file,
+              name,
+              md5: checksum(sql, newline),
+              getSql: () => sql
+            }
+          }
+        })
+      })
+      .then(migrations =>
+        migrations.filter(migration => !isNaN(migration.version))
+      )
+      .then(migrations => {
+        this.migrations = migrations
+        return migrations
+      })
   }
 
   /**

--- a/test/api.js
+++ b/test/api.js
@@ -71,12 +71,6 @@ describe('API', function() {
     })
     return patterngrator.getMigrations().then(migrationsByPattern => {
       assert.strictEqual(migrationsByPattern.length, 4)
-      // TODO make filename consistent
-      // With glob filename is full path. This is likely what we want
-      // assert.strictEqual(
-      //   migrationsByPattern[3].filename,
-      //   '002.do.fail-test.sql'
-      // )
     })
   })
 

--- a/test/api.js
+++ b/test/api.js
@@ -52,8 +52,14 @@ describe('API', function() {
       const m = migrations[0]
       assert.strictEqual(m.version, 1)
       assert.strictEqual(m.action, 'do')
+      // TODO make filename consistent
+      // With glob filename is full path. This is likely what we want instead of basename
       assert.strictEqual(m.filename, '001.do.sql')
+      assert.strictEqual(m.name, '')
       assert(m.hasOwnProperty('name'))
+
+      const m2 = migrations.find(m => m.version === 2 && m.action === 'do')
+      assert.strictEqual(m2.name, 'some-description')
     })
   })
 
@@ -63,12 +69,15 @@ describe('API', function() {
       migrationPattern: `${__dirname}/fail*/*`,
       connectionString: pgUrl
     })
-    patterngrator
-      .getMigrations()
-      .then(migrationsByPattern => {
-        assert.strictEqual(migrationsByPattern.length, 4)
-      })
-      .catch(err => console.log(err))
+    return patterngrator.getMigrations().then(migrationsByPattern => {
+      assert.strictEqual(migrationsByPattern.length, 4)
+      // TODO make filename consistent
+      // With glob filename is full path. This is likely what we want
+      // assert.strictEqual(
+      //   migrationsByPattern[3].filename,
+      //   '002.do.fail-test.sql'
+      // )
+    })
   })
 
   it('Implements getMaxVersion', function() {


### PR DESCRIPTION
Just some cleanup and small refactor to .getMigrations() in preparation of potentially expanding the types of migration scripts.

In doing so I realized there's an inconsistency in the migration.filename that is returned from postgrator. 