### PR TITLE
Add currentSchema config option for postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Postgres supports connection string url as well as simple ssl config:
 ```js
 const postgrator = new Postgrator({
   connectionString: 'tcp://username:password@hosturl/databasename',
-  ssl: true
+  ssl: true,
+  currentSchema: 'my-schema-name'  // migrations will only run against this schema
 })
 ```
 

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -117,6 +117,8 @@ module.exports = function(config) {
       if (schema[1]) {
         tableName = schema[1]
         schemaSql = `AND table_schema = '${schema[0]}'`
+      } else if (config.currentSchema) {
+        schemaSql = `AND table_schema = '${config.currentSchema}'`
       }
 
       sql = `

--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -269,11 +269,21 @@ function createPostgres(config, commonClient) {
     commonClient.dbConnection = new commonClient.dbDriver.Client(
       config.connectionString || config
     )
+
     // pg 6.x does not return promise on connect()
     // This wrapper should allow 6.x and 7.x compatibility
     return new Promise((resolve, reject) => {
       commonClient.dbConnection.connect(err => {
         if (err) return reject(err)
+        if (config.currentSchema) {
+          return commonClient.dbConnection.query(
+            `SET search_path = ${config.currentSchema}`,
+            err => {
+              if (err) return reject(err)
+              return resolve()
+            }
+          )
+        }
         return resolve()
       })
     })

--- a/test/drivers/pg.js
+++ b/test/drivers/pg.js
@@ -22,5 +22,19 @@ testConfig(
     password: 'postgrator',
     schemaTable: 'postgrator.schemaversion'
   },
-  'Driver: pg (with schema)'
+  'Driver: pg (with schemaTable)'
+)
+
+testConfig(
+  {
+    migrationDirectory: path.join(__dirname, '../migrations'),
+    driver: 'pg',
+    host: 'localhost',
+    port: 5432,
+    database: 'postgrator',
+    username: 'postgrator',
+    password: 'postgrator',
+    currentSchema: 'postgrator'
+  },
+  'Driver: pg (with currentSchema)'
 )


### PR DESCRIPTION
This allows the user to specify the postgres schema against which to run migrations. This is useful if, like myself, you are using schemas to create a mutli-tenanted app an your schemas are dynamically named