### PR TITLE
Added MSSQL Domain option

### DIFF
--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -328,6 +328,7 @@ function createMssql(config, commonClient) {
     server: config.host,
     port: config.port,
     database: config.database,
+    domain: config.domain,
     options: config.options,
     requestTimeout: config.requestTimeout || oneHour,
     connectionTimeout: config.connectionTimeout || 15000,


### PR DESCRIPTION
Added configuration option for domain login with sql server, I'm really not sure if this is the correct way to implement this, but adding this option allowed me to login in with my org's sql server configuration
see:
https://www.npmjs.com/package/mssql#general-same-for-all-drivers

