### PR TITLE
Add missing currentSchema Postgres option to the type

### DIFF
--- a/postgrator.d.ts
+++ b/postgrator.d.ts
@@ -53,6 +53,7 @@ declare namespace Postgrator {
     username?: string
     password?: string
     database?: string
+    currentSchema?: string
   }
 
   /**


### PR DESCRIPTION
The `currentSchema` option was introduced for PostgreSQL as per https://github.com/rickbergfalk/postgrator/commit/7c9cad93d4cea481c734f68fadf9430e30a5fd55#diff-04c6e90faac2675aa89e2176d2eec7d8R142 and https://github.com/rickbergfalk/postgrator/blob/master/CHANGELOG.md#380.

However, it is still missing from [`PostgreSQLOptions`](https://github.com/rickbergfalk/postgrator/blob/master/postgrator.d.ts#L46), so if one is using TypeScript and trying to use this option, then they can't compile their `.ts` code as `tsc` will give an error like this:

```
error TS2345: Argument of type '{ migrationDirectory: string; driver: "pg"; host: string; port: string; database: string; username: string; password: string; schemaTable: string; currentSchema: string; }' is not assignable to parameter of type 'Options'.
  Object literal may only specify known properties, and 'currentSchema' does not exist in type 'PostgreSQLOptions'.
```

This PR is adding the optional `currentSchema` property to the type.