### PR TITLE
MySQLOptions typings fix for mysql2

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const postgrator = new Postgrator({
   migrationDirectory: __dirname + '/migrations',
   // or a glob pattern to files
   migrationPattern: __dirname + '/some/pattern/*',
-  // Driver: must be pg, mysql, or mssql
+  // Driver: must be pg, mysql, mysql2 or mssql
   driver: 'pg',
   // Database connection config
   host: '127.0.0.1',

--- a/postgrator.d.ts
+++ b/postgrator.d.ts
@@ -32,7 +32,7 @@ declare namespace Postgrator {
    * Configuration options for MySQL connections
    */
   export interface MySQLOptions extends BaseOptions {
-    driver: 'mysql'
+    driver: 'mysql' | 'mysql2'
     host?: string
     port?: string | number
     username: string


### PR DESCRIPTION
Providing `mysql2` as a driver triggers TypeScript error. Fix attached.