### PR TITLE
fix mssql non default schema

### DIFF
--- a/lib/commonClient.js
+++ b/lib/commonClient.js
@@ -131,11 +131,24 @@ module.exports = function(config) {
     } else if (config.driver === 'mssql') {
       textType = 'VARCHAR(MAX)'
       columnKeyword = ''
+
+      const schema = config.schemaTable.split('.')
+      let tableName = schema[0]
+      let schemaSql = ''
+
+      if (schema[1]) {
+        tableName = schema[1]
+        schemaSql = `AND table_schema = '${schema[0]}'`
+      } else if (config.currentSchema) {
+        schemaSql = `AND table_schema = '${config.currentSchema}'`
+      }
+
       sql = `
         SELECT column_name
         FROM INFORMATION_SCHEMA.COLUMNS 
-        WHERE table_name = '${config.schemaTable}'
-        AND table_catalog = '${config.database}';
+        WHERE table_name = '${tableName}'
+        AND table_catalog = '${config.database}'
+        ${schemaSql};
       `
     } else if (config.driver === 'mysql' || config.driver === 'mysql2') {
       sql = `


### PR DESCRIPTION
The fix allows mssql users use non-default schema for postgrator. It repeats postgresql implementation.

test result  are same for both cases with and without my changes.

![image](https://user-images.githubusercontent.com/37807249/68717521-a9b46480-056c-11ea-9a48-ac8bf90c80d5.png)

not sure why 

 112 passing (7s)
  1 failing

getMajorVersion
    1) Detects db versions
    √ Fails gracefully for uninstalled module

I believe the changes is safe. You might need look why tests are bad (bad docker compose?).