### PR TITLE
Add POSTGRES_PASSWORD env variable in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   postgres:
     image: postgres:9.6-alpine
     environment:
+      POSTGRES_PASSWORD: postgrator
       POSTGRES_USER: postgrator
       POSTGRES_DB: postgrator
     ports: 


### PR DESCRIPTION
The Postgres tests were failing since the `postgres:9.6-alpine` image requires a `POSTGRES_PASSWORD` environment variable. This PR fixes the test suite by adding this environment variable.