### PR TITLE
Fix Postgres SSL typings

### DIFF
--- a/postgrator.d.ts
+++ b/postgrator.d.ts
@@ -1,3 +1,5 @@
+import { ConnectionOptions } from 'tls'
+
 declare namespace Postgrator {
 
   /**
@@ -45,7 +47,7 @@ declare namespace Postgrator {
    */
   export interface PostgreSQLOptions extends BaseOptions {
     driver: 'pg'
-    ssl?: boolean
+    ssl?: boolean | ConnectionOptions
     connectionString?: string
     host?: string
     port?: string | number


### PR DESCRIPTION
This PR improves typings for the Postgres `ssl` option. The `ssl` option is documented here: https://node-postgres.com/features/ssl