### PR TITLE
PostgreSQL applying Double Quotes when Using Pascal Case naming convention.

### DIFF
--- a/lib/PostgresClient.js
+++ b/lib/PostgresClient.js
@@ -1,24 +1,96 @@
 const Client = require('./Client')
+const utils = require('./utils')
 
 class PostgresClient extends Client {
+
+  charIsUpperCase(chr) {
+    return chr != chr.toLowerCase() && chr == chr.toUpperCase()
+  }
+
+  getName(name){
+   
+    if(this.charIsUpperCase(name[0])){
+      return `"${name}"`;
+    }
+    return name;
+  }
+
+  getSchemaTableName(schemaTable){
+
+    const schemaTableParts = schemaTable.split('.');
+    const schema = schemaTableParts[0]
+    const table = schemaTableParts[1]
+    
+    if(schema.length > 1){
+      return  `${this.getName(schema)}.${this.getName(table)}`
+    }
+  }
+
   getAddNameSql() {
+    const { config } = this;
+
     return `
-      ALTER TABLE ${this.config.schemaTable} 
+      ALTER TABLE ${this.getSchemaTableName(config.schemaTable)}
         ADD COLUMN name TEXT;
     `
   }
 
   getAddMd5Sql() {
+
+    const { config } = this;
+
     return `
-      ALTER TABLE ${this.config.schemaTable} 
+      ALTER TABLE ${this.getSchemaTableName(config.schemaTable)}
         ADD COLUMN md5 TEXT;
     `
   }
 
   getAddRunAtSql() {
+    const { config } = this;
     return `
-      ALTER TABLE ${this.config.schemaTable} 
+      ALTER TABLE ${this.getSchemaTableName(config.schemaTable)} 
         ADD COLUMN run_at TIMESTAMP WITH TIME ZONE;
+    `
+  }
+
+  persistActionSql(migration) {
+    const { config } = this
+    const action = migration.action.toLowerCase()
+    if (action === 'do') {
+      return `
+          INSERT INTO ${this.getSchemaTableName(config.schemaTable)} (version, name, md5, run_at) 
+          VALUES (
+            ${migration.version}, 
+            '${migration.name}', 
+            '${migration.md5}',
+            '${new Date().toISOString().replace('T', ' ').replace('Z', '')}'
+          );`
+    }
+    if (action === 'undo') {
+      return `
+          DELETE FROM ${this.getSchemaTableName(config.schemaTable)}
+          WHERE version = ${migration.version};`
+    }
+    throw new Error('unknown migration action')
+  }
+
+  getMd5Sql(migration) {
+    const { config } = this
+  
+    return `
+      SELECT md5 
+      FROM ${this.getSchemaTableName(config.schemaTable)}
+      WHERE version = ${migration.version};
+    `
+}
+
+  getDatabaseVersionSql() {
+    const { config } = this
+    return `
+      SELECT version 
+      FROM ${this.getSchemaTableName(config.schemaTable)}
+      ORDER BY version DESC 
+      LIMIT 1
     `
   }
 
@@ -48,6 +120,48 @@ class PostgresClient extends Client {
       ${tableCatalogSql}
       ${schemaSql};
     `
+  }
+
+  ensureTable() {
+    const { config } = this
+
+    const sql = this.getColumnsSql()
+    return this.runQuery(sql).then((results) => {
+      const { rows } = results
+      const sqls = []
+
+      if (rows.length === 0) {
+        if (config.driver === 'pg') {
+          // When using pg, create a schema if schemaTable has a `.` in it
+          const schema = config.schemaTable.split('.')
+          if (schema[1]) {
+            sqls.push(`CREATE SCHEMA IF NOT EXISTS ${schema[0]};`)
+          }
+        }
+
+        sqls.push(`
+          CREATE TABLE ${this.getSchemaTableName(config.schemaTable)} (
+            version BIGINT PRIMARY KEY
+          ); 
+          INSERT INTO ${this.getSchemaTableName(config.schemaTable)} (version) 
+            VALUES (0);
+        `)
+      }
+      if (!utils.hasColumnName(rows, 'name')) {
+        sqls.push(this.getAddNameSql())
+      }
+      if (!utils.hasColumnName(rows, 'md5')) {
+        sqls.push(this.getAddMd5Sql())
+      }
+      if (!utils.hasColumnName(rows, 'run_at')) {
+        sqls.push(this.getAddRunAtSql())
+      }
+      let sequence = Promise.resolve()
+      sqls.forEach((sql) => {
+        sequence = sequence.then(() => this.runQuery(sql))
+      })
+      return sequence
+    })
   }
 
   _createConnection() {

--- a/lib/PostgresClient.js
+++ b/lib/PostgresClient.js
@@ -7,7 +7,7 @@ class PostgresClient extends Client {
     return chr != chr.toLowerCase() && chr == chr.toUpperCase()
   }
 
-  getName(name){
+  doubleQuotePascalCase(name){
    
     if(this.charIsUpperCase(name[0])){
       return `"${name}"`;
@@ -22,7 +22,7 @@ class PostgresClient extends Client {
     const table = schemaTableParts[1]
     
     if(schema.length > 1){
-      return  `${this.getName(schema)}.${this.getName(table)}`
+      return  `${this.doubleQuotePascalCase(schema)}.${this.doubleQuotePascalCase(table)}`
     }
   }
 
@@ -135,7 +135,7 @@ class PostgresClient extends Client {
           // When using pg, create a schema if schemaTable has a `.` in it
           const schema = config.schemaTable.split('.')
           if (schema[1]) {
-            sqls.push(`CREATE SCHEMA IF NOT EXISTS ${schema[0]};`)
+            sqls.push(`CREATE SCHEMA IF NOT EXISTS ${this.doubleQuotePascalCase(schema[0])};`)
           }
         }
 

--- a/lib/PostgresClient.js
+++ b/lib/PostgresClient.js
@@ -18,12 +18,15 @@ class PostgresClient extends Client {
   getSchemaTableName(schemaTable){
 
     const schemaTableParts = schemaTable.split('.');
-    const schema = schemaTableParts[0]
-    const table = schemaTableParts[1]
     
-    if(schema.length > 1){
+    if(schemaTableParts.length > 1){
+
+      const schema = schemaTableParts[0]
+      const table = schemaTableParts[1]
       return  `${this.doubleQuotePascalCase(schema)}.${this.doubleQuotePascalCase(table)}`
     }
+
+    return this.doubleQuotePascalCase(schemaTable);
   }
 
   getAddNameSql() {

--- a/postgrator.js
+++ b/postgrator.js
@@ -48,7 +48,15 @@ class Postgrator extends EventEmitter {
     })
       .then((migrationFiles) => {
         return migrationFiles
-          .filter((file) => ['.sql', '.js'].indexOf(path.extname(file)) >= 0)
+          .filter((file) => {
+            let fileTypeMatch = ['.sql', '.js'].indexOf(path.extname(file)) >= 0;
+
+            const basenameNoExt = path.basename(file, path.extname(file))
+            let [version, action, name = ''] = basenameNoExt.split('.')
+            let actionTypeMatch = ['do','undo'].indexOf(action) >= 0;
+            
+            return fileTypeMatch && actionTypeMatch;
+          })
           .map((file) => {
             const basename = path.basename(file)
             const ext = path.extname(basename)


### PR DESCRIPTION
PostgreSQL requires the table and schema names to be double quoted when using Pascal Case Naming convention.

eg. If schema name is User and table name is Profile it should be quoted as "User"."Profile"

This PR  includes the changes to double quote that.

Regards.