### PR TITLE
Fix postgres ssl connection options

### DIFF
--- a/lib/PostgresClient.js
+++ b/lib/PostgresClient.js
@@ -60,7 +60,7 @@ class PostgresClient extends Client {
       dbDriver.defaults.ssl = true
     }
 
-    const dbConnection = new dbDriver.Client(config.connectionString || config)
+    const dbConnection = new dbDriver.Client(config)
     this.dbConnection = dbConnection
 
     // pg 6.x does not return promise on connect()


### PR DESCRIPTION
SSL connection options aren't passed through to the pg.Client if `config.connectionString` is present.

Example:-
If Postgrator is initialized like so
```js
const postgrator = new Postgrator({
  driver: 'pg',
  migrationDirectory: `...`,
  connectionString: "postgres://...",
  ssl: {
    rejectUnauthorized: false
  }
});
```
then the pg.Client is not initialized with the ssl options. 

Since `config.connectionString` is accepted by `pg.Client`, this change should be backward compatible.