### PR TITLE
Deprecate options and a method, and clean up README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Deprecate `host`, `port`, `username`, `password`, `ssl`, `options`, `currentSchema` config.
 - Deprecate `runQuery` utility function (use your db driver directly).
 - Deprecate `migrationDirectory` in favor of `migrationPattern` glob.
+
 ## 4.2.0
 
 ### July 25, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 4.3.0 (Unreleased)
+
+- Add `execQuery` function option to allow maximum flexibility in database connection management. Postgrator-owned database connections (the connections established using host, username, password, etc.) are deprecated, and will be removed in Postgrator 5.
+- Deprecate `host`, `port`, `username`, `password`, `ssl`, `options`, `currentSchema` config.
+- Deprecate `runQuery` utility function (use your db driver directly).
+- TODO deprecate one of the path configs for simplicity
 ## 4.2.0
 
 ### July 25, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add `execQuery` function option to allow maximum flexibility in database connection management. Postgrator-owned database connections (the connections established using host, username, password, etc.) are deprecated, and will be removed in Postgrator 5.
 - Deprecate `host`, `port`, `username`, `password`, `ssl`, `options`, `currentSchema` config.
 - Deprecate `runQuery` utility function (use your db driver directly).
-- TODO deprecate one of the path configs for simplicity
+- Deprecate `migrationDirectory` in favor of `migrationPattern` glob.
 ## 4.2.0
 
 ### July 25, 2021

--- a/README.md
+++ b/README.md
@@ -171,14 +171,11 @@ main();
 
 | option  | required  | description  | default |
 |---|---|---|---|
-|`migrationDirectory` | * | Path to directory containing migration files. |   |
-| `migrationPattern` | * | Glob pattern to migration files. |   |
+| `migrationPattern` | Required | Glob pattern to migration files. e.g. `path.join(__dirname, '/migrations/*')` |   |
 |`driver` | Required | Must be `pg`, `mysql`, `mysql2` or `mssql` |   |
 |`database`| Required | Target database name. |  |
 |`execQuery`| Required | Function to execute SQL. MUST return a promise containing an object with a rows array of objects. For example `{ rows: [{ column_name: 'column_value' }]}` |  |
 |`schemaTable`| Optional | Table created to track schema version. When using Postgres, you may specify schema as well, e.g. `schema_name.table_name`| `schemaversion` |
-
-\* Either `migrationDirectory` or `migrationPattern` required.
 
 
 ### Migrating to `execQuery` approach

--- a/README.md
+++ b/README.md
@@ -252,11 +252,10 @@ console.log(migrations)
 
 ## Tests
 
-A docker-compose file is provided with postgres and mysql (mariadb) containers
-configured for the tests. SQL Server tests also exist, but are commented out
-since the requirements are quite high to run them.
+A docker-compose file is provided with containers
+configured for tests.
 
-To run postgrator tests locally, you'll need Docker installed.
+To run postgrator tests locally, you'll need Docker and Docker Compose installed.
 
 ```sh
 # In one terminal window

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ database is at.
 
 Postgrator automatically determines whether it needs to go "up" or "down", and
 will update the schemaTable accordingly. If the database is already at the
-version specified to migrate to, Postgrator does nothing. 
+version specified to migrate to, Postgrator does nothing.
 
 ```js
 const Postgrator = require('postgrator')
@@ -126,7 +126,7 @@ async function main() {
 
   try {
     // Establish a database connection
-    await client.connect();
+    await client.connect()
 
     // Create a postgrator instance, with necessary info
     // * Where are migrations scripts located
@@ -142,47 +142,45 @@ async function main() {
       database: 'databasename',
       // Schema table name. Optional. Default is schemaversion
       schemaTable: 'schemaversion',
-      // Function to execute SQL. 
+      // Function to execute SQL.
       // MUST return Promise<{ rows: [{ column_name: 'column_value' }] }>
       // If using pg client, the library's query method has a compatible return value.
-      execQuery: (query) => client.query(query)
+      execQuery: (query) => client.query(query),
     })
 
     // Migrate to specific version
-    const appliedMigrations = await postgrator.migrate('002');
-    console.log(appliedMigrations);
+    const appliedMigrations = await postgrator.migrate('002')
+    console.log(appliedMigrations)
 
     // Or migrate to max version (optionally can provide 'max')
-    await postgrator.migrate();
+    await postgrator.migrate()
   } catch (error) {
     // If error happened partially through migrations,
     // error object is decorated with appliedMigrations
     console.error(error.appliedMigrations) // array of migration objects
   }
-  
+
   // Once done migrating, close your connection.
-  await client.end();
+  await client.end()
 }
-main();
+main()
 ```
 
 ### Options
 
-
-| option  | required  | description  | default |
-|---|---|---|---|
-| `migrationPattern` | Required | Glob pattern to migration files. e.g. `path.join(__dirname, '/migrations/*')` |   |
-|`driver` | Required | Must be `pg`, `mysql`, `mysql2` or `mssql` |   |
-|`database`| Required | Target database name. |  |
-|`execQuery`| Required | Function to execute SQL. MUST return a promise containing an object with a rows array of objects. For example `{ rows: [{ column_name: 'column_value' }]}` |  |
-|`schemaTable`| Optional | Table created to track schema version. When using Postgres, you may specify schema as well, e.g. `schema_name.table_name`| `schemaversion` |
-
+| option             | required | description                                                                                                                                                | default         |
+| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `migrationPattern` | Required | Glob pattern to migration files. e.g. `path.join(__dirname, '/migrations/*')`                                                                              |                 |
+| `driver`           | Required | Must be `pg`, `mysql`, `mysql2` or `mssql`                                                                                                                 |                 |
+| `database`         | Required | Target database name.                                                                                                                                      |                 |
+| `execQuery`        | Required | Function to execute SQL. MUST return a promise containing an object with a rows array of objects. For example `{ rows: [{ column_name: 'column_value' }]}` |                 |
+| `schemaTable`      | Optional | Table created to track schema version. When using Postgres, you may specify schema as well, e.g. `schema_name.table_name`                                  | `schemaversion` |
 
 ### Migrating to `execQuery` approach
 
 TODO: link to recipes
 
-If you used the `currentSchema` option with the now deprecated Postgrator-managed connections, you'll need to manage this yourself when switching to using `execQuery`. This can be accomplished by running `SET search_path = ${currentSchema}` prior to executing your SQL. 
+If you used the `currentSchema` option with the now deprecated Postgrator-managed connections, you'll need to manage this yourself when switching to using `execQuery`. This can be accomplished by running `SET search_path = ${currentSchema}` prior to executing your SQL.
 
 ### Checksum validation
 
@@ -268,16 +266,16 @@ Some of postgrator's methods may come in useful performing other migration tasks
 
 ```js
 // Get max version available from filesystem, as number, not string
-const maxVersionAvailable = await postgrator.getMaxVersion();
-console.log(maxVersionAvailable);
+const maxVersionAvailable = await postgrator.getMaxVersion()
+console.log(maxVersionAvailable)
 
 // "current" database schema version as number, not string
-const version = await postgrator.getDatabaseVersion();
-console.log(version);
+const version = await postgrator.getDatabaseVersion()
+console.log(version)
 
 // To get all migrations from directory and parse metadata
-const migrations = await postgrator.getMigrations();
-console.log(migrations);
+const migrations = await postgrator.getMigrations()
+console.log(migrations)
 ```
 
 ## Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,8 +1159,7 @@
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -2758,7 +2757,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "depd": "^2.0.0",
     "glob": "^7.2.0",
     "newline": "0.0.3"
   },

--- a/postgrator.js
+++ b/postgrator.js
@@ -69,6 +69,11 @@ class Postgrator extends EventEmitter {
         `Config option "options". Implement execQuery function instead.`
       )
     }
+    if (this.config.currentSchema) {
+      deprecate(
+        `Config option "currentSchema". Implement execQuery function instead, running "SET search_path" statement prior to executing your SQL.`
+      )
+    }
   }
 
   /**
@@ -157,6 +162,7 @@ class Postgrator extends EventEmitter {
    * @param {String} query sql query to execute
    */
   async runQuery(query) {
+    deprecate('runQuery. Use your db driver directly instead.')
     const { commonClient } = this
     const results = await commonClient.runQuery(query)
     await commonClient.endConnection()

--- a/postgrator.js
+++ b/postgrator.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const glob = require('glob')
 const EventEmitter = require('events')
+const deprecate = require('depd')('postgrator')
 
 const createCommonClient = require('./lib/createCommonClient.js')
 const {
@@ -40,6 +41,34 @@ class Postgrator extends EventEmitter {
     this.config = Object.assign({}, DEFAULT_CONFIG, config)
     this.migrations = []
     this.commonClient = createCommonClient(this.config)
+
+    // Instantiation with database credentials is deprecated
+    // Next major version of postgrator will require user manage the connection
+    // and provide the `execQuery` function
+    if (this.config.port) {
+      deprecate(`Config option "port". Implement execQuery function instead.`)
+    }
+    if (this.config.host) {
+      deprecate(`Config option "host". Implement execQuery function instead.`)
+    }
+    if (this.config.username) {
+      deprecate(
+        `Config option "username". Implement execQuery function instead.`
+      )
+    }
+    if (this.config.password) {
+      deprecate(
+        `Config option "password". Implement execQuery function instead.`
+      )
+    }
+    if (this.config.ssl) {
+      deprecate(`Config option "ssl". Implement execQuery function instead.`)
+    }
+    if (this.config.options) {
+      deprecate(
+        `Config option "options". Implement execQuery function instead.`
+      )
+    }
   }
 
   /**

--- a/postgrator.js
+++ b/postgrator.js
@@ -74,6 +74,11 @@ class Postgrator extends EventEmitter {
         `Config option "currentSchema". Implement execQuery function instead, running "SET search_path" statement prior to executing your SQL.`
       )
     }
+    if (this.config.migrationDirectory) {
+      deprecate(
+        `Config option "migrationDirectory". use "migrationPattern" instead using glob match. e.g. path.join(__dirname, '/migrations/*')`
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
Deprecates things that will be removed next major version of Postgrator. 

Updates README to use new preferred means of configuration (`execQuery` option), and edits documentation down a bit.