### PR TITLE
Fix version error when schemaversion table does not exist

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -71,6 +71,13 @@ class Client {
     return config.execQuery(query);
   }
 
+  async hasVersionTable() {
+    const sql = this.getColumnsSql();
+    const results = await this.runQuery(sql);
+    const { rows } = results;
+    return rows.length > 0;
+  }
+
   async ensureTable() {
     const { config } = this;
     const sql = this.getColumnsSql();

--- a/postgrator.js
+++ b/postgrator.js
@@ -112,6 +112,12 @@ class Postgrator extends EventEmitter {
    */
   async getDatabaseVersion() {
     const versionSql = this.commonClient.getDatabaseVersionSql();
+
+    const initialized = await this.commonClient.hasVersionTable();
+    if (!initialized) {
+      return undefined;
+    }
+
     const result = await this.commonClient.runQuery(versionSql);
     const version = result.rows.length > 0 ? result.rows[0].version : 0;
     return parseInt(version);

--- a/test/drivers.js
+++ b/test/drivers.js
@@ -83,6 +83,11 @@ function driverExecQuery(factoryFunction, label) {
       await end();
     });
 
+    it("Returns undefined for database version before init", async function () {
+      const result = await postgrator.getDatabaseVersion();
+      assert.strictEqual(result, undefined);
+    });
+
     it("Migrates multiple versions up (000 -> 002)", function () {
       return postgrator
         .migrate("002")


### PR DESCRIPTION
Fixes #139 by checking to see if any schemaversion columns exist in the database prior to attempting to get current database version. If no columns exist, the table does not exist, and so a version does not exist.