### PR TITLE
Fix typings for `getDatabaseVersion`

### DIFF
--- a/postgrator.d.ts
+++ b/postgrator.d.ts
@@ -91,11 +91,11 @@ declare class Postgrator {
 
   /**
    * Gets the database version of the schema from the database.
-   * Otherwise 0 if no version has been run
+   * Otherwise `undefined` if no version has been run
    *
    * @returns database schema version
    */
-  getDatabaseVersion(): Promise<number>;
+  getDatabaseVersion(): Promise<number | undefined>;
 
   /**
    * Returns an object with max version of migration available

--- a/postgrator.js
+++ b/postgrator.js
@@ -110,7 +110,7 @@ class Postgrator extends EventEmitter {
 
   /**
    * Gets the database version of the schema from the database.
-   * Otherwise 0 if no version has been run
+   * Otherwise `undefined` if no version has been run
    *
    * @returns {Promise} database schema version
    */

--- a/test/api.ts
+++ b/test/api.ts
@@ -57,7 +57,7 @@ describe("TypeScript API", function () {
   });
 
   it("Implements getDatabaseVersion", async () => {
-    const version: number = await postgrator.getDatabaseVersion();
+    const version: number | undefined = await postgrator.getDatabaseVersion();
     assert.strictEqual(version, 4);
   });
 


### PR DESCRIPTION
The function returns `undefined` when no migrations were applied yet.

This is a follow-up for https://github.com/rickbergfalk/postgrator/pull/142.