### PR TITLE
Fix DEP0151 warning about ext resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "type": "git",
     "url": "git://github.com/rickbergfalk/postgrator.git"
   },
-  "main": "postgrator",
+  "main": "postgrator.js",
   "types": "postgrator.d.ts",
   "devDependencies": {
     "@types/mocha": "^9.1.0",


### PR DESCRIPTION
Remove the following deprecation warning printed when the module
is imported:

    Automatic extension resolution of the "main" field is deprecated for ES modules.

Close #145
See also #143