### PR TITLE
Sqlite3 use INTEGER for the version type of the metadata table

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -94,7 +94,7 @@ class Client {
         if (schema[1]) {
           sqls.push(`CREATE SCHEMA IF NOT EXISTS "${schema[0]}";`);
         }
-      } else if (config.driver === "sqlite") {
+      } else if (config.driver === "sqlite3") {
         type = "INTEGER";
       }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -87,17 +87,20 @@ class Client {
     const sqls = [];
 
     if (rows.length === 0) {
+      let type = "BIGINT";
       if (config.driver === "pg") {
         // When using pg, create a schema if schemaTable has a `.` in it
         const schema = config.schemaTable.split(".");
         if (schema[1]) {
           sqls.push(`CREATE SCHEMA IF NOT EXISTS "${schema[0]}";`);
         }
+      } else if (config.driver === "sqlite") {
+        type = "INTEGER";
       }
 
       sqls.push(`
           CREATE TABLE ${this.quotedSchemaTable()} (
-            version BIGINT PRIMARY KEY
+            version ${type} PRIMARY KEY
           ); 
           INSERT INTO ${this.quotedSchemaTable()} (version) 
             VALUES (0);


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

In #150 I forgot to modify the datatype for the table in SQLite.
This is not functionally needed but more correct: https://www.sqlite.org/datatype3.html. 